### PR TITLE
Add standalone examples for documentation Good snippets

### DIFF
--- a/examples/ansi_colors.c
+++ b/examples/ansi_colors.c
@@ -1,0 +1,49 @@
+#define SP_IMPLEMENTATION
+#include "../sp.h"
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+static void free_str(sp_str_t str) {
+  if (str.data) {
+    sp_free((void*)str.data);
+  }
+}
+
+static const c8* get_error_from_some_external_library(void) {
+  return "an error occurred";
+}
+
+int main(void) {
+  sp_example_init();
+
+  sp_str_t formatted1 = sp_format("{:fg brightred}", SP_FMT_CSTR("FAILED"));
+  free_str(formatted1);
+
+  sp_str_t formatted2 = sp_format("{:fg brightcyan} tests failed", SP_FMT_U32(3));
+  free_str(formatted2);
+
+  sp_str_builder_t output = SP_ZERO_INITIALIZE();
+  sp_str_builder_append_fmt(&output, "{:fg brightgreen}", SP_FMT_CSTR("All tests passed"));
+  sp_str_t built = sp_str_builder_write(&output);
+  free_str(built);
+
+  sp_str_t status = SP_LIT("Some status message produced by your code");
+  sp_str_t formatted3 = sp_format("{:fg brightcyan}", SP_FMT_STR(status));
+  free_str(formatted3);
+
+  SP_LOG(
+    "{:fg brightyellow}: {:fg brightblack}",
+    SP_FMT_CSTR("warning"),
+    SP_FMT_CSTR(get_error_from_some_external_library())
+  );
+
+  sp_example_shutdown();
+  return 0;
+}

--- a/examples/bump_allocator.c
+++ b/examples/bump_allocator.c
@@ -1,0 +1,60 @@
+#define SP_IMPLEMENTATION
+#include <stddef.h>
+#include "../sp.h"
+
+typedef struct {
+  bool ok;
+} compile_result_t;
+
+typedef sp_hash_table(sp_str_t, u32) symbol_table_t;
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+static sp_dyn_array(sp_str_t) tokenize_file(sp_str_t source) {
+  sp_dyn_array(sp_str_t) tokens = SP_NULLPTR;
+  SP_UNUSED(source);
+  sp_dyn_array_push(tokens, SP_LIT("token1"));
+  sp_dyn_array_push(tokens, SP_LIT("token2"));
+  return tokens;
+}
+
+static compile_result_t compile(symbol_table_t table) {
+  SP_UNUSED(table);
+  return (compile_result_t){ .ok = true };
+}
+
+int main(void) {
+  sp_example_init();
+
+  sp_bump_allocator_t temp;
+  sp_allocator_t temp_allocator = sp_bump_allocator_init(&temp, 10 * 1024 * 1024);
+  sp_context_push_allocator(temp_allocator);
+
+  sp_str_t source = SP_LIT("fn main() {}");
+  sp_dyn_array(sp_str_t) tokens = tokenize_file(source);
+  symbol_table_t symbol_table = sp_hash_table_new(sp_str_t, u32);
+  sp_hash_table_init(symbol_table, sp_str_t, u32);
+
+  for (u32 i = 0; i < sp_dyn_array_size(tokens); i++) {
+    sp_str_t symbol = sp_str_copy(tokens[i]);
+    sp_hash_table_insert(symbol_table, symbol, i);
+  }
+
+  compile_result_t result = compile(symbol_table);
+  SP_UNUSED(result);
+
+  sp_hash_table_free(symbol_table);
+  sp_dyn_array_free(tokens);
+  sp_context_pop();
+  sp_bump_allocator_clear(&temp);
+
+  sp_example_shutdown();
+  return 0;
+}

--- a/examples/c_strings_only_at_api_boundaries.c
+++ b/examples/c_strings_only_at_api_boundaries.c
@@ -1,0 +1,64 @@
+#define SP_IMPLEMENTATION
+#include "../sp.h"
+
+#define sp_export
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+static void SDL_Log(const char* fmt, ...) {
+  SP_UNUSED(fmt);
+}
+
+static void process_config(sp_str_t config) {
+  SP_UNUSED(config);
+}
+
+static void process_arguments(sp_dyn_array(sp_str_t) args) {
+  SP_UNUSED(args);
+}
+
+void my_log_wrapper(sp_str_t message) {
+  c8* cstr = sp_str_to_cstr(message);
+  SDL_Log("%s", cstr);
+  sp_free(cstr);
+}
+
+sp_export void plugin_init(const char* config_path) {
+  sp_str_t config = sp_str_from_cstr(config_path);
+
+  sp_str_t parent = sp_os_parent_path(config);
+  sp_str_t stem = sp_os_extract_stem(config);
+
+  process_config(config);
+
+  sp_free((void*)config.data);
+  sp_free((void*)parent.data);
+  SP_UNUSED(stem);
+}
+
+int main(int argc, char** argv) {
+  sp_example_init();
+
+  sp_dyn_array(sp_str_t) args = SP_NULLPTR;
+  for (s32 i = 1; i < argc; i++) {
+    sp_dyn_array_push(args, sp_str_from_cstr(argv[i]));
+  }
+
+  process_arguments(args);
+  if (args) {
+    for (u32 i = 0; i < sp_dyn_array_size(args); i++) {
+      sp_free((void*)args[i].data);
+    }
+  }
+  sp_dyn_array_free(args);
+
+  sp_example_shutdown();
+  return 0;
+}

--- a/examples/carr_for.c
+++ b/examples/carr_for.c
@@ -1,0 +1,37 @@
+#define SP_IMPLEMENTATION
+#include "../sp.h"
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+int main(void) {
+  sp_example_init();
+
+  sp_formatter_t formatters[] = {
+      { .id = SP_FMT_ID(str), .fn = sp_fmt_format_str },
+      { .id = SP_FMT_ID(u32), .fn = sp_fmt_format_u32 },
+      { .id = SP_FMT_ID(f32), .fn = sp_fmt_format_f32 },
+  };
+
+  sp_str_builder_t builder = SP_ZERO_INITIALIZE();
+  sp_format_arg_t arg = SP_FMT_ARG(str, SP_LIT("value"));
+
+  SP_CARR_FOR(formatters, i) {
+      if (arg.id == formatters[i].id) {
+          formatters[i].fn(&builder, &arg);
+          break;
+      }
+  }
+
+  sp_str_t output = sp_str_builder_write(&builder);
+  sp_free((void*)output.data);
+
+  sp_example_shutdown();
+  return 0;
+}

--- a/examples/compound_literals.c
+++ b/examples/compound_literals.c
@@ -1,0 +1,53 @@
+#define SP_IMPLEMENTATION
+#include "../sp.h"
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+typedef struct {
+  char cFileName[260];
+} fake_find_data_t;
+
+int main(void) {
+  sp_example_init();
+
+  sp_str_t file_path = SP_LIT("C:/temp/file.txt");
+  fake_find_data_t find_data = { "file.txt" };
+  sp_os_file_attr_t attrs = SP_OS_FILE_ATTR_NONE;
+
+  sp_os_directory_entry_t entry = SP_RVAL(sp_os_directory_entry_t) {
+      .file_path = file_path,
+      .file_name = sp_str_from_cstr(find_data.cFileName),
+#ifdef SP_WIN32
+      .attributes = sp_os_winapi_attr_to_sp_attr(attrs),
+#else
+      .attributes = attrs,
+#endif
+  };
+
+  sp_precise_epoch_time_t time = SP_RVAL(sp_precise_epoch_time_t) {
+      .s = 1234,
+      .ns = 0
+  };
+
+  sp_str_t str = SP_LIT("example");
+  u32 start = 1;
+  u32 end = 4;
+  sp_str_t substr = SP_RVAL(sp_str_t) {
+      .len = end - start,
+      .data = str.data + start
+  };
+
+  sp_free((void*)entry.file_name.data);
+  SP_UNUSED(time);
+  SP_UNUSED(substr);
+
+  sp_example_shutdown();
+  return 0;
+}

--- a/examples/context_allocator.c
+++ b/examples/context_allocator.c
@@ -1,0 +1,31 @@
+#define SP_IMPLEMENTATION
+#include "../sp.h"
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+int main(void) {
+  sp_example_init();
+
+  sp_bump_allocator_t bump_allocator;
+  sp_allocator_t bump = sp_bump_allocator_init(&bump_allocator, 1024 * 1024);
+
+  sp_context_push_allocator(bump);
+  sp_str_t path = sp_str_from_cstr("/tmp/example/file.txt");
+  sp_dyn_array(sp_str_t) parts = sp_str_split_c8(path, '/');
+
+  sp_dyn_array_free(parts);
+  sp_context_pop();
+  sp_bump_allocator_clear(&bump_allocator);
+
+  sp_free((void*)path.data);
+
+  sp_example_shutdown();
+  return 0;
+}

--- a/examples/dynamic_array.c
+++ b/examples/dynamic_array.c
@@ -1,0 +1,37 @@
+#define SP_IMPLEMENTATION
+#include "../sp.h"
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+static void compile_file(sp_str_t file) {
+  SP_LOG("compiling {}", SP_FMT_STR(file));
+}
+
+int main(void) {
+  sp_example_init();
+
+  sp_dyn_array(sp_str_t) files = SP_NULLPTR;
+
+  sp_dyn_array_push(files, SP_LIT("main.c"));
+  sp_dyn_array_push(files, SP_LIT("utils.c"));
+  sp_dyn_array_push(files, SP_LIT("test.c"));
+
+  sp_dyn_array_for(files, i) {
+    compile_file(files[i]);
+  }
+
+  u32 count = sp_dyn_array_size(files);
+  SP_LOG("total files: {}", SP_FMT_U32(count));
+
+  sp_dyn_array_free(files);
+
+  sp_example_shutdown();
+  return 0;
+}

--- a/examples/enum_names.c
+++ b/examples/enum_names.c
@@ -1,0 +1,56 @@
+#define SP_IMPLEMENTATION
+#include "../sp.h"
+
+typedef enum {
+  EVENT_INIT,
+  EVENT_UPDATE,
+  EVENT_DRAW,
+  EVENT_QUIT
+} event_type_t;
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+const c8* event_type_to_cstr(event_type_t type) {
+  switch (type) {
+    SP_SWITCH_ENUM_TO_CSTR(EVENT_INIT);
+    SP_SWITCH_ENUM_TO_CSTR(EVENT_UPDATE);
+    SP_SWITCH_ENUM_TO_CSTR(EVENT_DRAW);
+    SP_SWITCH_ENUM_TO_CSTR(EVENT_QUIT);
+    default: return "UNKNOWN";
+  }
+}
+
+sp_str_t event_type_to_str(event_type_t type) {
+  return SP_CSTR(event_type_to_cstr(type));
+}
+
+const c8* event_type_to_lower(event_type_t type) {
+  switch (type) {
+    case EVENT_INIT:   return "init";
+    case EVENT_UPDATE: return "update";
+    case EVENT_DRAW:   return "draw";
+    case EVENT_QUIT:   return "quit";
+    default: return "unknown";
+  }
+}
+
+void log_event(event_type_t type) {
+  SP_LOG("Processing event: {}", SP_FMT_CSTR(event_type_to_cstr(type)));
+}
+
+int main(void) {
+  sp_example_init();
+
+  log_event(EVENT_INIT);
+  log_event(EVENT_QUIT);
+
+  sp_example_shutdown();
+  return 0;
+}

--- a/examples/error_avoid_nesting.c
+++ b/examples/error_avoid_nesting.c
@@ -1,0 +1,103 @@
+#define SP_IMPLEMENTATION
+#include "../sp.h"
+
+typedef struct CXIndexImpl* CXIndex;
+typedef struct CXTranslationUnitImpl* CXTranslationUnit;
+
+typedef enum {
+  CXError_Success = 0,
+  CXError_Failure = 1,
+} CXErrorCode;
+
+typedef CXErrorCode enum_CXErrorCode;
+
+typedef struct {
+  int dummy;
+} CXUnsused;
+
+static CXIndex clang_createIndex(int exclude_decls, int display_diags) {
+  SP_UNUSED(exclude_decls);
+  SP_UNUSED(display_diags);
+  return (CXIndex)1;
+}
+
+static CXErrorCode clang_parseTranslationUnit2(
+    CXIndex index,
+    const char* source_filename,
+    void* command_line_args,
+    int num_command_line_args,
+    void* unsaved_files,
+    unsigned num_unsaved_files,
+    unsigned options,
+    CXTranslationUnit* out_unit) {
+  SP_UNUSED(index);
+  SP_UNUSED(source_filename);
+  SP_UNUSED(command_line_args);
+  SP_UNUSED(num_command_line_args);
+  SP_UNUSED(unsaved_files);
+  SP_UNUSED(num_unsaved_files);
+  SP_UNUSED(options);
+  if (out_unit) {
+    *out_unit = (CXTranslationUnit)1;
+  }
+  return CXError_Success;
+}
+
+static void clang_disposeTranslationUnit(CXTranslationUnit unit) {
+  SP_UNUSED(unit);
+}
+
+static void clang_disposeIndex(CXIndex index) {
+  SP_UNUSED(index);
+}
+
+static bool process_ast(CXTranslationUnit unit) {
+  SP_UNUSED(unit);
+  return true;
+}
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+bool process_file(sp_str_t path) {
+  CXIndex index = clang_createIndex(0, 1);
+  CXTranslationUnit unit = NULL;
+  bool success = false;
+  c8* path_cstr = sp_str_to_cstr(path);
+
+  CXErrorCode error = clang_parseTranslationUnit2(
+    index, path_cstr, NULL, 0, NULL, 0,
+    0, &unit
+  );
+
+  if (error != CXError_Success) {
+    SP_LOG("Failed to parse {}: error {}", SP_FMT_STR(path), SP_FMT_S32(error));
+    goto cleanup;
+  }
+
+  if (!process_ast(unit)) {
+    SP_LOG("AST processing failed");
+    goto cleanup;
+  }
+
+  success = true;
+
+cleanup:
+  if (unit) clang_disposeTranslationUnit(unit);
+  if (index) clang_disposeIndex(index);
+  sp_free(path_cstr);
+  return success;
+}
+
+int main(void) {
+  sp_example_init();
+  process_file(SP_LIT("example.c"));
+  sp_example_shutdown();
+  return 0;
+}

--- a/examples/file_monitor.c
+++ b/examples/file_monitor.c
@@ -1,0 +1,48 @@
+#define SP_IMPLEMENTATION
+#include "../sp.h"
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+static void trigger_rebuild(void) {
+  SP_LOG_STR(SP_LIT("triggering rebuild"));
+}
+
+void on_file_change(sp_file_monitor_t* monitor, sp_file_change_t* change, void* userdata) {
+  SP_UNUSED(monitor);
+  SP_UNUSED(userdata);
+  if (change->events & SP_FILE_CHANGE_EVENT_MODIFIED) {
+    if (sp_str_ends_with(change->file_name, SP_LIT(".c"))) {
+      trigger_rebuild();
+    }
+  }
+}
+
+int main(void) {
+  sp_example_init();
+
+  void* userdata = NULL;
+  bool running = false;
+
+  sp_file_monitor_t monitor;
+  sp_file_monitor_init_debounce(&monitor, on_file_change,
+      SP_FILE_CHANGE_EVENT_MODIFIED | SP_FILE_CHANGE_EVENT_ADDED,
+      userdata, 100);
+
+  sp_file_monitor_add_directory(&monitor, SP_LIT("src"));
+  sp_file_monitor_add_directory(&monitor, SP_LIT("include"));
+
+  while (running) {
+    sp_file_monitor_process_changes(&monitor);
+    sp_os_sleep_ms(50);
+  }
+
+  sp_example_shutdown();
+  return 0;
+}

--- a/examples/format_string.c
+++ b/examples/format_string.c
@@ -1,0 +1,50 @@
+#define SP_IMPLEMENTATION
+#include "../sp.h"
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+static void release_formatted(sp_str_t str) {
+  if (str.data) {
+    sp_free((void*)str.data);
+  }
+}
+
+int main(void) {
+  sp_example_init();
+
+  u32 file_count = 42;
+  f32 elapsed = 16.7f;
+  sp_str_t base_dir = SP_LIT("/tmp");
+  sp_str_t filename = SP_LIT("data.bin");
+  bool is_running = true;
+  u32 port = 8080;
+  u32 rgb_value = 0x33cc99;
+
+  sp_str_t msg = sp_format("{} files processed in {}ms",
+      SP_FMT_U32(file_count), SP_FMT_F32(elapsed));
+  sp_str_t path = sp_format("{}/{}",
+      SP_FMT_STR(base_dir), SP_FMT_STR(filename));
+  sp_str_t quoted = sp_format("Error in file {}",
+      SP_FMT_QUOTED_STR(filename));
+  sp_str_t status = sp_format("Server {} on port {}",
+      SP_FMT_CSTR(is_running ? "running" : "stopped"),
+      SP_FMT_U32(port));
+  sp_str_t hex = sp_format("Color: 0x{:06x}",
+      SP_FMT_U32(rgb_value));
+
+  release_formatted(msg);
+  release_formatted(path);
+  release_formatted(quoted);
+  release_formatted(status);
+  release_formatted(hex);
+
+  sp_example_shutdown();
+  return 0;
+}

--- a/examples/hash_functions.c
+++ b/examples/hash_functions.c
@@ -1,0 +1,44 @@
+#define SP_IMPLEMENTATION
+#include "../sp.h"
+
+typedef struct {
+  sp_str_t data;
+  u32 len;
+} file_data_t;
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+int main(void) {
+  sp_example_init();
+
+  const c8* filename = "example.txt";
+  u8 buffer[] = { 1, 2, 3, 4, 5 };
+  u32 buffer_size = (u32)(sizeof(buffer) / sizeof(buffer[0]));
+  sp_hash_t hashes[] = { 10, 20, 30 };
+  u32 hash_count = (u32)(sizeof(hashes) / sizeof(hashes[0]));
+
+  file_data_t file_data = {
+    .data = SP_LIT("contents"),
+    .len = 8,
+  };
+
+  sp_hash_t file_hash = sp_hash_cstr(filename);
+  sp_hash_t data_hash = sp_hash_bytes(buffer, buffer_size, 0);
+  sp_hash_t combined = sp_hash_combine(hashes, hash_count);
+  sp_hash_t content_hash = sp_hash_bytes((const u8*)file_data.data.data, file_data.len, 42);
+
+  SP_UNUSED(file_hash);
+  SP_UNUSED(data_hash);
+  SP_UNUSED(combined);
+  SP_UNUSED(content_hash);
+
+  sp_example_shutdown();
+  return 0;
+}

--- a/examples/logging.c
+++ b/examples/logging.c
@@ -1,0 +1,47 @@
+#define SP_IMPLEMENTATION
+#include "../sp.h"
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+void log_error(sp_str_t file, u32 line, sp_str_t msg) {
+  sp_log(SP_LIT("{:color red} in {}:{} - {}"),
+      SP_FMT_CSTR("ERROR"),
+      SP_FMT_STR(file),
+      SP_FMT_U32(line),
+      SP_FMT_STR(msg));
+}
+
+#define LOG_DEBUG(msg) \
+    SP_LOG("[DEBUG] {} ({}:{})", \
+        SP_FMT_CSTR(msg), \
+        SP_FMT_CSTR(__FILE__), \
+        SP_FMT_U32(__LINE__))
+
+int main(void) {
+  sp_example_init();
+
+  u32 port = 8080;
+  SP_LOG("Server started on port {}", SP_FMT_U32(port));
+
+  sp_str_t status = SP_LIT("ready");
+  sp_log(SP_LIT("Status: {}"), SP_FMT_STR(status));
+
+  SP_LOG_STR(SP_LIT("Initialization complete"));
+
+  u32 test_count = 12;
+  SP_LOG("{:color green} tests passed", SP_FMT_U32(test_count));
+
+  log_error(SP_LIT("main.c"), 42, SP_LIT("failed to initialize"));
+
+  LOG_DEBUG("setup complete");
+
+  sp_example_shutdown();
+  return 0;
+}

--- a/examples/macro_utilities.c
+++ b/examples/macro_utilities.c
@@ -1,0 +1,47 @@
+#define SP_IMPLEMENTATION
+#include "../sp.h"
+
+#define MY_FUNC_NAME(type) SP_MACRO_CAT(process_, type)
+#define MY_STRUCT_NAME(name) SP_MACRO_CAT(name, _data_t)
+
+static void MY_FUNC_NAME(int)(int value) { SP_UNUSED(value); }
+static void MY_FUNC_NAME(float)(float value) { SP_UNUSED(value); }
+
+typedef struct MY_STRUCT_NAME(player) {
+    u32 id;
+    sp_str_t name;
+} player_data_t;
+
+#define LOG_VAR(var) \
+    SP_LOG("{} = {}", SP_FMT_CSTR(SP_MACRO_STR(var)), SP_FMT_U32(var))
+
+#define DECLARE_HANDLE(name) \
+    typedef struct SP_MACRO_CAT(name, _impl_t)* name##_t
+
+DECLARE_HANDLE(window);
+DECLARE_HANDLE(renderer);
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+int main(void) {
+  sp_example_init();
+
+  u32 count = 42;
+  LOG_VAR(count);
+
+  MY_FUNC_NAME(int)(5);
+  MY_FUNC_NAME(float)(1.0f);
+
+  player_data_t player = { .id = 1, .name = SP_LIT("player1") };
+  SP_UNUSED(player);
+
+  sp_example_shutdown();
+  return 0;
+}

--- a/examples/parse_numbers.c
+++ b/examples/parse_numbers.c
@@ -1,0 +1,54 @@
+#define SP_IMPLEMENTATION
+#include "../sp.h"
+
+typedef bool sp_parse_result_t;
+#define SP_PARSE_OK true
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+static void server_listen(u32 port) {
+  SP_LOG("listening on port {}", SP_FMT_U32(port));
+}
+
+static void set_background_color(u32 color) {
+  SP_LOG("background color: 0x{:06x}", SP_FMT_U32(color));
+}
+
+static void set_target_fps(f32 fps) {
+  SP_LOG("target fps: {}", SP_FMT_F32(fps));
+}
+
+int main(void) {
+  sp_example_init();
+
+  sp_str_t port_str = SP_LIT("8080");
+  u32 port = 0;
+  sp_parse_result_t result = sp_parse_u32_ex(port_str, &port);
+  if (result == SP_PARSE_OK) {
+    server_listen(port);
+  }
+
+  sp_str_t hex_color = SP_LIT("ff00aa");
+  u32 color = 0;
+  u64 color64 = 0;
+  if (sp_parse_hex_ex(hex_color, &color64)) {
+    color = (u32)color64;
+    set_background_color(color);
+  }
+
+  sp_str_t fps_str = SP_LIT("60.5");
+  f32 fps = 0.0f;
+  if (sp_parse_f32_ex(fps_str, &fps)) {
+    set_target_fps(fps);
+  }
+
+  sp_example_shutdown();
+  return 0;
+}

--- a/examples/path_operations.c
+++ b/examples/path_operations.c
@@ -1,0 +1,41 @@
+#define SP_IMPLEMENTATION
+#include "../sp.h"
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+static void free_str(sp_str_t str) {
+  if (str.data) {
+    sp_free((void*)str.data);
+  }
+}
+
+int main(void) {
+  sp_example_init();
+
+  sp_str_t exe = sp_os_get_executable_path();
+  sp_str_t config_path = sp_os_join_path(sp_os_parent_path(exe), SP_LIT("config.toml"));
+
+  sp_str_t filename = sp_os_extract_file_name(config_path);
+  sp_str_t stem = sp_os_extract_stem(config_path);
+  sp_str_t ext = sp_os_extract_extension(config_path);
+
+  sp_str_t canonical = sp_os_canonicalize_path(SP_LIT("../data/./files"));
+
+  SP_UNUSED(filename);
+  SP_UNUSED(stem);
+  SP_UNUSED(ext);
+
+  free_str(exe);
+  free_str(config_path);
+  free_str(canonical);
+
+  sp_example_shutdown();
+  return 0;
+}

--- a/examples/qsort_compare.c
+++ b/examples/qsort_compare.c
@@ -1,0 +1,33 @@
+#define SP_IMPLEMENTATION
+#include "../sp.h"
+#include <stdlib.h>
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+sp_dyn_array(sp_str_t) get_file_list(void) {
+  sp_dyn_array(sp_str_t) files = SP_NULLPTR;
+  sp_dyn_array_push(files, SP_LIT("src/main.c"));
+  sp_dyn_array_push(files, SP_LIT("src/app.c"));
+  sp_dyn_array_push(files, SP_LIT("src/zeta.c"));
+  sp_dyn_array_push(files, SP_LIT("src/core.c"));
+  return files;
+}
+
+int main(void) {
+  sp_example_init();
+
+  sp_dyn_array(sp_str_t) files = get_file_list();
+  qsort(files, sp_dyn_array_size(files), sizeof(sp_str_t), sp_str_sort_kernel_alphabetical);
+
+  sp_dyn_array_free(files);
+
+  sp_example_shutdown();
+  return 0;
+}

--- a/examples/ring_buffer.c
+++ b/examples/ring_buffer.c
@@ -1,0 +1,50 @@
+#define SP_IMPLEMENTATION
+#include "../sp.h"
+
+typedef enum {
+  KEY_PRESS,
+  KEY_RELEASE,
+} event_type_t;
+
+typedef struct {
+  event_type_t type;
+  c8 key;
+} event_t;
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+static void process_event(event_t* event) {
+  SP_LOG("event type {}", SP_FMT_U32((u32)event->type));
+}
+
+int main(void) {
+  sp_example_init();
+
+  sp_ring_buffer_t events;
+  sp_ring_buffer_init(&events, 100, sizeof(event_t));
+
+  event_t evt = { .type = KEY_PRESS, .key = 'A' };
+  sp_ring_buffer_push_overwrite(&events, &evt);
+
+  sp_ring_buffer_for(events, it) {
+    event_t* e = sp_rb_it(it, event_t);
+    process_event(e);
+  }
+
+  sp_ring_buffer_rfor(events, it) {
+    event_t* e = sp_rb_it(it, event_t);
+    if (e->type == KEY_PRESS) break;
+  }
+
+  sp_ring_buffer_destroy(&events);
+
+  sp_example_shutdown();
+  return 0;
+}

--- a/examples/sdl_integration.c
+++ b/examples/sdl_integration.c
@@ -1,0 +1,117 @@
+#define SP_IMPLEMENTATION
+#include "../sp.h"
+
+typedef struct SDL_Process {
+  int dummy;
+} SDL_Process;
+
+typedef struct SDL_Environment {
+  int dummy;
+} SDL_Environment;
+
+static SDL_Process* SDL_CreateProcess(char* const* args, bool inherit_handles, int pipes) {
+  SP_UNUSED(args);
+  SP_UNUSED(inherit_handles);
+  SP_UNUSED(pipes);
+  static SDL_Process process;
+  return &process;
+}
+
+static u8* SDL_ReadProcess(SDL_Process* process, size_t* output_size, void* error) {
+  SP_UNUSED(process);
+  SP_UNUSED(error);
+  static u8 buffer[] = "ok";
+  *output_size = sizeof(buffer) - 1;
+  return buffer;
+}
+
+static s32 SDL_WaitProcess(SDL_Process* process, bool block) {
+  SP_UNUSED(process);
+  SP_UNUSED(block);
+  return 0;
+}
+
+static void SDL_free(void* ptr) {
+  SP_UNUSED(ptr);
+}
+
+static SDL_Environment* SDL_GetEnvironment(void) {
+  static SDL_Environment env;
+  return &env;
+}
+
+static const char* SDL_GetEnvironmentVariable(SDL_Environment* env, const char* name) {
+  SP_UNUSED(env);
+  SP_UNUSED(name);
+  return "PATH";
+}
+
+static void SDL_SetEnvironmentVariable(SDL_Environment* env, const char* name, const char* value, bool overwrite) {
+  SP_UNUSED(env);
+  SP_UNUSED(name);
+  SP_UNUSED(value);
+  SP_UNUSED(overwrite);
+}
+
+static const char* SDL_GetBasePath(void) {
+  return "/tmp";
+}
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+static char** sp_str_to_cstr_array(sp_str_t command) {
+  char** args = (char**)sp_alloc(sizeof(char*) * 2);
+  args[0] = sp_str_to_cstr(command);
+  args[1] = NULL;
+  return args;
+}
+
+static void sp_free_cstr_array(char** args) {
+  if (!args) return;
+  if (args[0]) {
+    sp_free(args[0]);
+  }
+  sp_free(args);
+}
+
+int main(void) {
+  sp_example_init();
+
+  sp_str_t project_dir = SP_LIT("/tmp/project");
+  sp_str_t command = sp_format("make -C {} build", SP_FMT_STR(project_dir));
+  char** args = sp_str_to_cstr_array(command);
+
+  SDL_Process* process = SDL_CreateProcess(args, true, SP_SDL_PIPE_STDIO);
+
+  size_t output_size = 0;
+  u8* output = SDL_ReadProcess(process, &output_size, NULL);
+  s32 exit_code = SDL_WaitProcess(process, true);
+
+  if (exit_code == 0) {
+    sp_str_t result = sp_str((c8*)output, (u32)output_size);
+    SP_LOG("process output: {}", SP_FMT_STR(result));
+  }
+  SDL_free(output);
+
+  sp_str_t env_path = sp_str_from_cstr(SDL_GetEnvironmentVariable(SDL_GetEnvironment(), "PATH"));
+  SDL_SetEnvironmentVariable(SDL_GetEnvironment(), "CUSTOM_VAR", "value", true);
+
+  sp_str_t base_path = sp_str_from_cstr(SDL_GetBasePath());
+
+  sp_free_cstr_array(args);
+  if (command.data) {
+    sp_free((void*)command.data);
+  }
+  sp_free((void*)env_path.data);
+  sp_free((void*)base_path.data);
+
+  sp_example_shutdown();
+  return 0;
+}

--- a/examples/string_literal.c
+++ b/examples/string_literal.c
@@ -1,0 +1,36 @@
+#define SP_IMPLEMENTATION
+#include "../sp.h"
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+static void process_text_file(sp_str_t file) {
+  SP_LOG("processing text file: {}", SP_FMT_STR(file));
+}
+
+int main(void) {
+  sp_example_init();
+
+  sp_str_builder_t builder = SP_ZERO_INITIALIZE();
+  sp_str_t path = SP_LIT("/home/user");
+  sp_str_t delimiter = SP_LIT(", ");
+  sp_str_builder_append(&builder, SP_LIT("Error: "));
+
+  sp_str_t ext = SP_LIT(".txt");
+  sp_str_t file = SP_LIT("report.txt");
+  if (sp_str_equal(ext, SP_LIT(".txt"))) {
+    process_text_file(file);
+  }
+
+  SP_UNUSED(path);
+  SP_UNUSED(delimiter);
+
+  sp_example_shutdown();
+  return 0;
+}

--- a/examples/string_map.c
+++ b/examples/string_map.c
@@ -1,0 +1,50 @@
+#define SP_IMPLEMENTATION
+#include "../sp.h"
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+static void free_str_array(sp_dyn_array(sp_str_t) array) {
+  if (!array) return;
+  for (u32 i = 0; i < sp_dyn_array_size(array); i++) {
+    if (array[i].data) {
+      sp_free((void*)array[i].data);
+    }
+  }
+  sp_dyn_array_free(array);
+}
+
+int main(void) {
+  sp_example_init();
+
+  sp_str_t lines[] = {
+      SP_LIT("  hello world  "),
+      SP_LIT("\ttest line\n"),
+      SP_LIT("  another  "),
+  };
+
+  sp_dyn_array(sp_str_t) trimmed = sp_str_map(lines, 3, NULL, sp_str_map_kernel_trim);
+  sp_dyn_array(sp_str_t) upper = sp_str_map(lines, 3, NULL, sp_str_map_kernel_to_upper);
+
+  u32 width = 20;
+  sp_dyn_array(sp_str_t) padded = sp_str_map(lines, 3, &width, sp_str_map_kernel_pad);
+
+  sp_str_t longest = sp_str_find_longest_n(lines, 3);
+  sp_dyn_array(sp_str_t) aligned = sp_str_pad_to_longest(lines, 3);
+
+  SP_LOG("longest line has {} characters", SP_FMT_U32(longest.len));
+
+  free_str_array(trimmed);
+  free_str_array(upper);
+  free_str_array(padded);
+  free_str_array(aligned);
+
+  sp_example_shutdown();
+  return 0;
+}

--- a/examples/string_padding.c
+++ b/examples/string_padding.c
@@ -1,0 +1,60 @@
+#define SP_IMPLEMENTATION
+#include "../sp.h"
+
+typedef struct {
+  sp_str_t name;
+  sp_str_t status;
+  sp_str_t path;
+} dependency_t;
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+static void free_str(sp_str_t str) {
+  if (str.data) {
+    sp_free((void*)str.data);
+  }
+}
+
+static void free_str_array(sp_dyn_array(sp_str_t) array) {
+  if (!array) return;
+  for (u32 i = 0; i < sp_dyn_array_size(array); i++) {
+    free_str(array[i]);
+  }
+  sp_dyn_array_free(array);
+}
+
+int main(void) {
+  sp_example_init();
+
+  dependency_t dep_instance = {
+    .name = SP_LIT("spn"),
+    .status = SP_LIT("ready"),
+    .path = SP_LIT("/tmp/project"),
+  };
+  dependency_t* dep = &dep_instance;
+
+  sp_str_t name = sp_str_pad(dep->name, 20);
+  sp_str_t status = sp_str_pad(dep->status, 10);
+  SP_LOG("{} {} {}", SP_FMT_STR(name), SP_FMT_STR(status), SP_FMT_STR(dep->path));
+
+  sp_str_t names[] = {
+    SP_LIT("alice"),
+    SP_LIT("bob"),
+    SP_LIT("charlotte"),
+  };
+  sp_dyn_array(sp_str_t) padded = sp_str_pad_to_longest(names, 3);
+
+  free_str(name);
+  free_str(status);
+  free_str_array(padded);
+
+  sp_example_shutdown();
+  return 0;
+}

--- a/examples/string_prefix_checking.c
+++ b/examples/string_prefix_checking.c
@@ -1,0 +1,53 @@
+#define SP_IMPLEMENTATION
+#include "../sp.h"
+
+typedef struct {
+  sp_str_t file_name;
+} entry_t;
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+static void use_secure_connection(sp_str_t url) {
+  SP_LOG("using https for {}", SP_FMT_STR(url));
+}
+
+static void use_standard_connection(sp_str_t url) {
+  SP_LOG("using http for {}", SP_FMT_STR(url));
+}
+
+int main(void) {
+  sp_example_init();
+
+  sp_str_t url = SP_LIT("https://example.com");
+
+  if (sp_str_starts_with(url, SP_LIT("https://"))) {
+    use_secure_connection(url);
+  }
+  else if (sp_str_starts_with(url, SP_LIT("http://"))) {
+    use_standard_connection(url);
+  }
+
+  sp_dyn_array(entry_t) entries = SP_NULLPTR;
+  entry_t hidden = { .file_name = SP_LIT(".hidden") };
+  entry_t visible = { .file_name = SP_LIT("visible.txt") };
+  sp_dyn_array_push(entries, hidden);
+  sp_dyn_array_push(entries, visible);
+
+  sp_dyn_array_for(entries, i) {
+    if (sp_str_starts_with(entries[i].file_name, SP_LIT("."))) {
+      continue;
+    }
+  }
+
+  sp_dyn_array_free(entries);
+
+  sp_example_shutdown();
+  return 0;
+}

--- a/examples/string_slicing.c
+++ b/examples/string_slicing.c
@@ -1,0 +1,41 @@
+#define SP_IMPLEMENTATION
+#include "../sp.h"
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+int main(void) {
+  sp_example_init();
+
+  sp_str_t path = SP_LIT("/home/user/documents/file.txt");
+
+  sp_str_t filename = sp_os_extract_file_name(path);
+  sp_str_t extension = sp_os_extract_extension(path);
+  sp_str_t stem = sp_os_extract_stem(path);
+
+  sp_str_t first_10 = sp_str_sub(path, 0, 10);
+  sp_str_t last_4 = sp_str_sub_reverse(path, 0, 4);
+
+  if (sp_str_ends_with(path, SP_LIT(".txt"))) {
+    sp_str_t without_ext = sp_str_sub(path, 0, path.len - 4);
+    SP_UNUSED(without_ext);
+  }
+
+  sp_dyn_array(sp_str_t) parts = sp_str_split_c8(path, '/');
+
+  SP_UNUSED(filename);
+  SP_UNUSED(extension);
+  SP_UNUSED(stem);
+  SP_UNUSED(first_10);
+  SP_UNUSED(last_4);
+  SP_UNUSED(parts);
+
+  sp_example_shutdown();
+  return 0;
+}

--- a/examples/switch_over_if.c
+++ b/examples/switch_over_if.c
@@ -1,0 +1,80 @@
+#define SP_IMPLEMENTATION
+#include "../sp.h"
+
+typedef enum {
+    CMD_INIT,
+    CMD_BUILD,
+    CMD_TEST,
+    CMD_CLEAN,
+    CMD_HELP
+} command_t;
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+static void init_project(void) { SP_LOG_STR(SP_LIT("init")); }
+static void build_project(void) { SP_LOG_STR(SP_LIT("build")); }
+static void run_tests(void) { SP_LOG_STR(SP_LIT("test")); }
+static void clean_artifacts(void) { SP_LOG_STR(SP_LIT("clean")); }
+static void show_help(void) { SP_LOG_STR(SP_LIT("help")); }
+
+command_t parse_command(sp_str_t cmd) {
+    if (sp_str_equal_cstr(cmd, "init"))  return CMD_INIT;
+    if (sp_str_equal_cstr(cmd, "build")) return CMD_BUILD;
+    if (sp_str_equal_cstr(cmd, "test"))  return CMD_TEST;
+    if (sp_str_equal_cstr(cmd, "clean")) return CMD_CLEAN;
+    return CMD_HELP;
+}
+
+void execute_command(command_t cmd) {
+    switch (cmd) {
+        case CMD_INIT:
+            init_project();
+            break;
+
+        case CMD_BUILD:
+            build_project();
+            break;
+
+        case CMD_TEST:
+            run_tests();
+            break;
+
+        case CMD_CLEAN:
+            clean_artifacts();
+            break;
+
+        case CMD_HELP:
+            show_help();
+            break;
+
+        default: {
+            SP_UNREACHABLE_CASE();
+        }
+    }
+}
+
+const c8* command_to_string(command_t cmd) {
+    switch (cmd) {
+        case CMD_INIT:  return "init";
+        case CMD_BUILD: return "build";
+        case CMD_TEST:  return "test";
+        case CMD_CLEAN: return "clean";
+        case CMD_HELP:  return "help";
+        default: return "unknown";
+    }
+}
+
+int main(void) {
+  sp_example_init();
+  execute_command(parse_command(SP_LIT("build")));
+  SP_UNUSED(command_to_string(CMD_TEST));
+  sp_example_shutdown();
+  return 0;
+}

--- a/examples/switch_patterns.c
+++ b/examples/switch_patterns.c
@@ -1,0 +1,95 @@
+#define SP_IMPLEMENTATION
+#include "../sp.h"
+
+typedef enum {
+  TOKEN_NUMBER,
+  TOKEN_STRING,
+  TOKEN_PLUS,
+  TOKEN_MINUS,
+  TOKEN_SPACE,
+} token_type_t;
+
+typedef struct {
+  token_type_t type;
+} token_t;
+
+typedef enum {
+  BUILD_PENDING,
+  BUILD_RUNNING,
+  BUILD_SUCCESS,
+  BUILD_FAILED,
+} build_status_t;
+
+static void parse_number(token_t* token) { SP_UNUSED(token); }
+static void parse_string(token_t* token) { SP_UNUSED(token); }
+static void parse_operator(token_t* token) { SP_UNUSED(token); }
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+int main(void) {
+  sp_example_init();
+
+  token_t token = { .type = TOKEN_NUMBER };
+  switch (token.type) {
+    case TOKEN_NUMBER: {
+      parse_number(&token);
+      break;
+    }
+
+    case TOKEN_STRING: {
+      parse_string(&token);
+      break;
+    }
+
+    case TOKEN_PLUS:
+    case TOKEN_MINUS: {
+      parse_operator(&token);
+      break;
+    }
+
+    case TOKEN_SPACE: {
+      break;
+    }
+
+    default: {
+      SP_UNREACHABLE_CASE();
+    }
+  }
+
+  build_status_t build_status = BUILD_SUCCESS;
+  sp_str_t target = SP_LIT("target");
+  sp_str_t msg = SP_ZERO_STRUCT(sp_str_t);
+
+  switch (build_status) {
+    case BUILD_PENDING: {
+      msg = sp_format("{:fg brightblack} {}", SP_FMT_CSTR("[ ]"), SP_FMT_STR(target));
+      break;
+    }
+    case BUILD_RUNNING: {
+      msg = sp_format("{:fg yellow} {}", SP_FMT_CSTR("[.]"), SP_FMT_STR(target));
+      break;
+    }
+    case BUILD_SUCCESS: {
+      msg = sp_format("{:fg green} {}", SP_FMT_CSTR("[+]"), SP_FMT_STR(target));
+      break;
+    }
+    case BUILD_FAILED: {
+      msg = sp_format("{:fg red} {}", SP_FMT_CSTR("[-]"), SP_FMT_STR(target));
+      break;
+    }
+  }
+
+  if (msg.data) {
+    sp_free((void*)msg.data);
+  }
+
+  sp_example_shutdown();
+  return 0;
+}

--- a/examples/test_macros.c
+++ b/examples/test_macros.c
@@ -1,0 +1,55 @@
+#define SP_IMPLEMENTATION
+#include "../sp.h"
+
+#define UTEST(suite, name) static void test_##suite##_##name(void)
+#define RUN_UTEST(suite, name) test_##suite##_##name()
+#define ASSERT_EQ(a, b) SP_ASSERT((a) == (b))
+#define ASSERT_NE(a, b) SP_ASSERT((a) != (b))
+#define SP_EXPECT_STR_EQ_CSTR(str, cstr) SP_ASSERT(sp_str_equal_cstr((str), (cstr)))
+#define SP_EXPECT_STR_EQ(a, b) SP_ASSERT(sp_str_equal((a), (b)))
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+UTEST(string_operations, trimming) {
+    sp_str_t input = SP_LIT("  hello world  ");
+    sp_str_t result = sp_str_trim(input);
+
+    SP_EXPECT_STR_EQ_CSTR(result, "hello world");
+
+    sp_str_t empty = SP_LIT("   \t\n  ");
+    result = sp_str_trim(empty);
+    SP_EXPECT_STR_EQ_CSTR(result, "");
+
+    sp_str_t a = SP_LIT("test");
+    sp_str_t b = SP_LIT("test");
+    SP_EXPECT_STR_EQ(a, b);
+}
+
+UTEST(format_system, basic) {
+    sp_str_t msg = sp_format("{} + {} = {}",
+        SP_FMT_U32(10), SP_FMT_U32(20), SP_FMT_U32(30));
+
+    SP_EXPECT_STR_EQ_CSTR(msg, "10 + 20 = 30");
+
+    ASSERT_EQ(msg.len, 13);
+    ASSERT_NE(msg.data, SP_NULLPTR);
+
+    if (msg.data) {
+      sp_free((void*)msg.data);
+    }
+}
+
+int main(void) {
+  sp_example_init();
+  RUN_UTEST(string_operations, trimming);
+  RUN_UTEST(format_system, basic);
+  sp_example_shutdown();
+  return 0;
+}

--- a/examples/thread_sync.c
+++ b/examples/thread_sync.c
@@ -1,0 +1,68 @@
+#define SP_IMPLEMENTATION
+#include "../sp.h"
+
+typedef struct {
+  int id;
+} task_t;
+
+typedef struct {
+  bool stop;
+  sp_mutex_t queue_mutex;
+  sp_semaphore_t done_sem;
+  task_t queue[4];
+  u32 queue_size;
+} worker_data_t;
+
+static worker_data_t worker_data;
+
+static void process_task(task_t* task) {
+  SP_UNUSED(task);
+}
+
+static s32 worker_thread(void* userdata) {
+  worker_data_t* data = (worker_data_t*)userdata;
+
+  while (!data->stop) {
+    sp_mutex_lock(&data->queue_mutex);
+    if (data->queue_size > 0) {
+      task_t task = data->queue[--data->queue_size];
+      sp_mutex_unlock(&data->queue_mutex);
+
+      process_task(&task);
+
+      sp_semaphore_signal(&data->done_sem);
+    } else {
+      sp_mutex_unlock(&data->queue_mutex);
+      sp_os_sleep_ms(10);
+    }
+  }
+  return 0;
+}
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+int main(void) {
+  sp_example_init();
+
+  sp_mutex_init(&worker_data.queue_mutex, SP_MUTEX_PLAIN);
+  sp_semaphore_init(&worker_data.done_sem);
+  worker_data.queue_size = 1;
+  worker_data.queue[0] = (task_t){ .id = 1 };
+  worker_data.stop = false;
+
+  sp_thread_t thread;
+  sp_thread_init(&thread, worker_thread, &worker_data);
+  sp_semaphore_wait(&worker_data.done_sem);
+  worker_data.stop = true;
+  sp_thread_join(&thread);
+
+  sp_example_shutdown();
+  return 0;
+}

--- a/examples/zero_initialize.c
+++ b/examples/zero_initialize.c
@@ -1,0 +1,34 @@
+#define SP_IMPLEMENTATION
+#include "../sp.h"
+
+static void sp_example_init(void) {
+  sp_config_t config = { .allocator = sp_malloc_allocator_init() };
+  sp_init(config);
+}
+
+static void sp_example_shutdown(void) {
+  sp_context_pop();
+}
+
+typedef struct {
+  u32 count;
+  f32* values;
+  sp_mutex_t mutex;
+} complex_data_t;
+
+int main(void) {
+  sp_example_init();
+
+  sp_file_monitor_t monitor = SP_ZERO_INITIALIZE();
+  sp_str_builder_t builder = SP_ZERO_INITIALIZE();
+  sp_ring_buffer_iterator_t it = SP_ZERO_INITIALIZE();
+  complex_data_t data = SP_ZERO_INITIALIZE();
+
+  SP_UNUSED(monitor);
+  SP_UNUSED(builder);
+  SP_UNUSED(it);
+  SP_UNUSED(data);
+
+  sp_example_shutdown();
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add an `examples` directory with per-topic C programs that implement the "Good" snippets from the documentation
- extend the Makefile with optional `spn`/`bear` detection and pattern rules so `make <example>` builds to `build/bin`

## Testing
- make examples

------
https://chatgpt.com/codex/tasks/task_e_68d2c6eb1194832dad2084e2ef797d05