### PR TITLE
mem: prefer heap allocator in most cases

### DIFF
--- a/example/app.c
+++ b/example/app.c
@@ -28,7 +28,8 @@ void on_deinit(sp_app_t* app) {
 }
 
 sp_app_config_t app_main(s32 num_args, const c8** args) {
-  sp_mem_t a = sp_mem_os_new();
+  sp_mem_heap_t* heap = sp_mem_heap_new();
+  sp_mem_t a = sp_mem_heap_as_allocator(heap);
   state_t* state = sp_alloc_type(a, state_t);
   state->allocator = a;
 

--- a/example/array.c
+++ b/example/array.c
@@ -2,7 +2,9 @@
 #include "sp.h"
 
 s32 run(s32 num_args, const c8** args) {
-  sp_da(u32) years = sp_da_new(sp_mem_os_new(), u32);
+  sp_mem_heap_t* heap = sp_mem_heap_new();
+  sp_mem_t mem = sp_mem_heap_as_allocator(heap);
+  sp_da(u32) years = sp_da_new(mem, u32);
   sp_da_push(years, 1969);
   sp_da_push(years, 1972);
   sp_da_for(years, it) {

--- a/example/format.c
+++ b/example/format.c
@@ -55,7 +55,8 @@ void specifier(s64 n, c8 fill, sp_fmt_align_t align, u8 width) {
 }
 
 s32 run(s32 num_args, const c8** args) {
-  sp_mem_t mem = sp_mem_os_new();
+  sp_mem_heap_t* heap = sp_mem_heap_new();
+  sp_mem_t mem = sp_mem_heap_as_allocator(heap);
 
   sp_log("{.green} has Zig/Rust style format specifiers (fill, align, width), plus named directives which may:", sp_fmt_cstr("sp.h"));
   sp_log("- {} text from a format argument", sp_fmt_cstr("render"));

--- a/example/hash_table.c
+++ b/example/hash_table.c
@@ -11,7 +11,8 @@ void header(const c8* key, const c8* value) {
 }
 
 s32 run(s32 num_args, const c8** args) {
-  sp_mem_t a = sp_mem_os_new();
+  sp_mem_heap_t* heap = sp_mem_heap_new();
+  sp_mem_t a = sp_mem_heap_as_allocator(heap);
 
   struct {
     sp_ht(s32, u32)            integer;

--- a/example/io.c
+++ b/example/io.c
@@ -2,7 +2,8 @@
 #include "sp.h"
 
 s32 run(s32 num_args, const c8** args) {
-  sp_mem_t mem = sp_mem_os_new();
+  sp_mem_heap_t* heap = sp_mem_heap_new();
+  sp_mem_t mem = sp_mem_heap_as_allocator(heap);
 
   sp_io_file_reader_t r = sp_zero;
 

--- a/example/ls.c
+++ b/example/ls.c
@@ -8,7 +8,8 @@ s32 compare_entries(const void* pa, const void* pb) {
 }
 
 s32 run(s32 num_args, const c8** args) {
-  sp_mem_t mem = sp_mem_os_new();
+  sp_mem_heap_t* heap = sp_mem_heap_new();
+  sp_mem_t mem = sp_mem_heap_as_allocator(heap);
   sp_str_t cwd = sp_fs_get_cwd(mem);
   sp_str_t dir = cwd;
   if (num_args == 2) dir = sp_fs_join_path(mem, cwd, sp_str_view(args[1]));

--- a/example/msvc.c
+++ b/example/msvc.c
@@ -12,7 +12,9 @@ s32 msvc_main(s32 argc, const c8** argv) {
   (void)argv;
 
   sp_msvc_t result = sp_zero;
-  sp_msvc_err_t err = sp_msvc_find(sp_mem_os_new(), SP_MSVC_ARCH_X64, &result);
+  sp_mem_heap_t* heap = sp_mem_heap_new();
+  sp_mem_t mem = sp_mem_heap_as_allocator(heap);
+  sp_msvc_err_t err = sp_msvc_find(mem, SP_MSVC_ARCH_X64, &result);
 
   if (err) {
     sp_log("sp_msvc_find failed: {}", sp_fmt_int(err));

--- a/example/palette.c
+++ b/example/palette.c
@@ -235,7 +235,8 @@ sp_app_config_t app_main(s32 num_args, const c8** args) {
   if (num_args > 2) saturation = sp_parse_s32(sp_str_view(args[2]));
   if (num_args > 3) value      = sp_parse_s32(sp_str_view(args[3]));
 
-  sp_mem_t mem = sp_mem_os_new();
+  sp_mem_heap_t* heap = sp_mem_heap_new();
+  sp_mem_t mem = sp_mem_heap_as_allocator(heap);
   app_t* app = sp_alloc_type(mem, app_t);
   app->mem = mem;
   app->saved_colors = sp_da_new(app->mem, sp_color_t);

--- a/example/prompt.c
+++ b/example/prompt.c
@@ -376,7 +376,8 @@ s32 prompt_main(s32 argc, const c8** argv) {
     { "Knight Rider", demo_knight_rider },
   };
 
-  sp_mem_t mem = sp_mem_os_new();
+  sp_mem_heap_t* heap = sp_mem_heap_new();
+  sp_mem_t mem = sp_mem_heap_as_allocator(heap);
 
   sp_ht(const c8*, sp_prompt_demo_fn_t) demos = sp_zero;
   sp_cstr_ht_init(mem, demos);
@@ -398,7 +399,7 @@ s32 prompt_main(s32 argc, const c8** argv) {
     run = *fn;
   }
 
-  sp_prompt_ctx_t* ctx = sp_prompt_begin(sp_mem_os_new());
+  sp_prompt_ctx_t* ctx = sp_prompt_begin(mem);
   if (!ctx) {
     return SP_PROMPT_ERROR;
   }

--- a/example/prompt_fancy.c
+++ b/example/prompt_fancy.c
@@ -545,7 +545,9 @@ static sp_str_t fancy_plan_note(sp_mem_t mem, const c8* kind, const c8* name, co
 
 s32 fancy_main(s32 argc, const c8** argv) {
   bool scripted = fancy_has_arg(argc, argv, "--scripted");
-  sp_prompt_ctx_t* ctx = sp_prompt_begin(sp_mem_os_new());
+  sp_mem_heap_t* heap = sp_mem_heap_new();
+  sp_mem_t mem = sp_mem_heap_as_allocator(heap);
+  sp_prompt_ctx_t* ctx = sp_prompt_begin(mem);
   if (ctx == SP_NULLPTR) {
     sp_log("failed to initialize prompt");
     return 1;

--- a/example/wc.c
+++ b/example/wc.c
@@ -7,7 +7,8 @@ s32 run(s32 num_args, const c8** args) {
     return 1;
   }
 
-  sp_mem_t mem = sp_mem_os_new();
+  sp_mem_heap_t* heap = sp_mem_heap_new();
+  sp_mem_t mem = sp_mem_heap_as_allocator(heap);
 
   sp_str_t cwd = sp_fs_get_cwd(mem);
   sp_str_t path = sp_fs_join_path(mem, cwd, sp_str_view(args[1]));

--- a/example/zero_copy.c
+++ b/example/zero_copy.c
@@ -152,8 +152,8 @@ static void report(const c8* label, run_t run) {
 }
 
 s32 run(s32 num_args, const c8** args) {
-  (void)num_args; (void)args;
-  sp_mem_t mem = sp_mem_arena_as_allocator(sp_mem_arena_new(sp_mem_os_new()));
+  sp_mem_heap_t* heap = sp_mem_heap_new();
+  sp_mem_t mem = sp_mem_heap_as_allocator(heap);
 
   sp_str_t cwd = sp_fs_get_cwd(mem);
   sp_str_t src = sp_str_concat(mem, cwd, sp_str_lit("/io.src"));

--- a/sp.h
+++ b/sp.h
@@ -3158,7 +3158,13 @@ SP_TYPEDEF_FN(void, sp_tls_once_fn_t);
 SP_TYPEDEF_FN(void, sp_tls_deinit_fn_t, void*);
 
 typedef struct {
-  sp_mem_t mem;
+  struct {
+    sp_mem_heap_t* heap;
+  } allocators;
+  struct {
+    sp_mem_t heap;
+    sp_mem_t page;
+  } mem;
   sp_mem_arena_t* scratch [2];
   sp_env_t env;
   struct {
@@ -7117,7 +7123,7 @@ void* sp_rb_grow_ex(void* arr, u32 stride, u32 capacity) {
 // @format
 void sp_fmt_directive_register(const c8* name, sp_fmt_directive_t directive) {
   sp_tls_rt_t* tls = sp_tls_rt_get();
-  sp_str_t id = sp_str_from_cstr(tls->mem, name);
+  sp_str_t id = sp_str_from_cstr(tls->mem.heap, name);
   sp_str_ht_insert(tls->format.directives, id, directive);
 }
 
@@ -7993,12 +7999,13 @@ void sp_rt_init() {
 void sp_tls_rt_deinit(void* ptr) {
   if (!ptr) return;
   sp_tls_rt_t* tls = (sp_tls_rt_t*)ptr;
-  if (tls->std.out) sp_mem_allocator_free(tls->mem, tls->std.out, sizeof(sp_io_stream_writer_t));
-  if (tls->std.err) sp_mem_allocator_free(tls->mem, tls->std.err, sizeof(sp_io_stream_writer_t));
+  if (tls->std.out) sp_mem_allocator_free(tls->mem.heap, tls->std.out, sizeof(sp_io_stream_writer_t));
+  if (tls->std.err) sp_mem_allocator_free(tls->mem.heap, tls->std.err, sizeof(sp_io_stream_writer_t));
   sp_str_ht_free(tls->format.directives);
   sp_carr_for(tls->scratch, it) {
     sp_mem_arena_destroy(tls->scratch[it]);
   }
+  sp_mem_heap_destroy(tls->allocators.heap);
   sp_sys_free(tls, sizeof(sp_tls_rt_t));
 }
 
@@ -8011,16 +8018,18 @@ sp_tls_rt_t* sp_tls_rt_get() {
     // before doing anything else so you can call functions that allocate
     // while initializing the other TLS stuff.
     tls = sp_sys_alloc_type(sp_tls_rt_t);
-    tls->mem = sp_mem_os_new();
+    tls->allocators.heap = sp_mem_heap_new();
+    tls->mem.heap = sp_mem_heap_as_allocator(tls->allocators.heap);
+    tls->mem.page = sp_mem_os_new();
     sp_tls_set(sp_rt.tls.key, tls);
 
     sp_carr_for(tls->scratch, it) {
-      tls->scratch[it] = sp_mem_arena_new(tls->mem);
+      tls->scratch[it] = sp_mem_arena_new(tls->mem.page);
     }
     // std.out/std.err are wired lazily (see sp_tls_std_out/_err). Wiring them here
     // would take the address of sp_io_stream_writer_write in code that sp_main always
     // reaches, which on WASM forces a fd_write import even for programs that never write.
-    sp_str_ht_init(tls->mem, tls->format.directives);
+    sp_str_ht_init(tls->mem.heap, tls->format.directives);
     sp_fmt_register_builtins();
     sp_sys_tls_init(tls);
   }
@@ -8029,7 +8038,7 @@ sp_tls_rt_t* sp_tls_rt_get() {
 
 sp_io_writer_t* sp_tls_std_out(sp_tls_rt_t* tls) {
   if (!tls->std.out) {
-    tls->std.out = sp_alloc_type(tls->mem, sp_io_stream_writer_t);
+    tls->std.out = sp_alloc_type(tls->mem.heap, sp_io_stream_writer_t);
     sp_io_stream_writer_from_fd(tls->std.out, sp_sys_stdout, SP_IO_CLOSE_MODE_NONE);
   }
   return &tls->std.out->base;
@@ -8037,7 +8046,7 @@ sp_io_writer_t* sp_tls_std_out(sp_tls_rt_t* tls) {
 
 sp_io_writer_t* sp_tls_std_err(sp_tls_rt_t* tls) {
   if (!tls->std.err) {
-    tls->std.err = sp_alloc_type(tls->mem, sp_io_stream_writer_t);
+    tls->std.err = sp_alloc_type(tls->mem.heap, sp_io_stream_writer_t);
     sp_io_stream_writer_from_fd(tls->std.err, sp_sys_stderr, SP_IO_CLOSE_MODE_NONE);
   }
   return &tls->std.err->base;
@@ -14356,7 +14365,8 @@ SP_API s32 sp_app_run_free(sp_app_t* app) {
 }
 
 SP_API s32 sp_app_run(sp_app_config_t config) {
-  sp_mem_t mem = sp_mem_os_new();
+  sp_mem_heap_t* heap = sp_mem_heap_new();
+  sp_mem_t mem = sp_mem_heap_as_allocator(heap);
   sp_app_t* app = sp_app_new(mem, config);
   s32 rc = (app->mode == SP_APP_MODE_FREE)
     ? sp_app_run_free(app)

--- a/test/cv.c
+++ b/test/cv.c
@@ -4,6 +4,20 @@
 #include "utest.h"
 SP_TEST_MAIN()
 
+struct cv {
+  sp_mem_heap_t* heap;
+  sp_mem_t mem;
+};
+
+UTEST_F_SETUP(cv) {
+  ut.heap = sp_mem_heap_new();
+  ut.mem = sp_mem_heap_as_allocator(ut.heap);
+}
+
+UTEST_F_TEARDOWN(cv) {
+  sp_mem_heap_destroy(ut.heap);
+}
+
 UTEST(cv, init_destroy) {
   SKIP_ON_WASM()
   SKIP_ON_FREESTANDING()
@@ -339,13 +353,13 @@ s32 consumer_fn(void* userdata) {
   return 0;
 }
 
-UTEST(cv, multithread_producer_consumer) {
+UTEST_F(cv, multithread_producer_consumer) {
   SKIP_ON_WASM()
   SKIP_ON_FREESTANDING()
   sp_cv_t cv = sp_zero;
   sp_mutex_t mutex = sp_zero;
   sp_rb(s32) buffer = SP_NULLPTR;
-  sp_rb_init(sp_mem_os_new(), buffer);
+  sp_rb_init(ut.mem, buffer);
 
   sp_cv_init(&cv);
   sp_mutex_init(&mutex, SP_MUTEX_PLAIN);

--- a/test/env.c
+++ b/test/env.c
@@ -16,14 +16,17 @@ SP_TEST_MAIN()
 #endif
 
 struct env {
+  sp_mem_heap_t* heap;
   sp_mem_t mem;
 };
 
 UTEST_F_SETUP(env) {
-  ut.mem = sp_mem_os_new();
+  ut.heap = sp_mem_heap_new();
+  ut.mem = sp_mem_heap_as_allocator(ut.heap);
 }
 
 UTEST_F_TEARDOWN(env) {
+  sp_mem_heap_destroy(ut.heap);
 }
 
 UTEST_F(env, init_empty) {
@@ -265,7 +268,7 @@ UTEST_F(env, iterate) {
 }
 
 UTEST_F(env, iterate_matches_capture) {
-  sp_env_t captured = sp_env_capture(sp_mem_os_new());
+  sp_env_t captured = sp_env_capture(ut.mem);
 
   sp_os_env_it_t it = sp_os_env_it_begin();
   u32 it_count = 0;

--- a/test/format.c
+++ b/test/format.c
@@ -15,7 +15,7 @@ static sp_ht(sp_str_t, sp_fmt_directive_t) sp_fmt_directives = SP_NULLPTR;
 void sp_fmt_directive_reset() {
   sp_tls_rt_t* tls = sp_tls_rt_get();
   sp_str_ht_free(tls->format.directives);
-  sp_str_ht_init(tls->mem, tls->format.directives);
+  sp_str_ht_init(tls->mem.heap, tls->format.directives);
   sp_fmt_register_builtins();
 }
 

--- a/test/fs/get_cwd.c
+++ b/test/fs/get_cwd.c
@@ -1,30 +1,42 @@
 #include "fs.h"
 
-UTEST(fs_get_cwd, contract) {
+struct fs_get_cwd {
+  sp_mem_heap_t* heap;
+  sp_mem_t mem;
+};
+
+UTEST_F_SETUP(fs_get_cwd) {
+  ut.heap = sp_mem_heap_new();
+  ut.mem = sp_mem_heap_as_allocator(ut.heap);
+}
+
+UTEST_F_TEARDOWN(fs_get_cwd) {
+  sp_mem_heap_destroy(ut.heap);
+}
+
+UTEST_F(fs_get_cwd, contract) {
   SKIP_ON_WASM()
-  sp_mem_t a = sp_mem_os_new();
-  sp_str_t cwd = sp_fs_get_cwd(a);
+  sp_str_t cwd = sp_fs_get_cwd(ut.mem);
   ASSERT_TRUE(sp_fs_is_dir(cwd));
   ASSERT_TRUE(sp_fs_is_absolute(cwd));
 }
 
-UTEST(fs_get_cwd, unlinked_cwd_does_not_leak_deleted_suffix) {
+UTEST_F(fs_get_cwd, unlinked_cwd_does_not_leak_deleted_suffix) {
   // @spader
 #if !defined(SP_LINUX)
   UTEST_SKIP("unlinked-cwd is a Linux-only scenario");
 #else
-  sp_mem_t a = sp_mem_os_new();
-  sp_str_t original = sp_fs_get_cwd(a);
+  sp_str_t original = sp_fs_get_cwd(ut.mem);
   ASSERT_GT(original.len, 0);
 
-  sp_str_t sandbox = sp_fs_join_path(a, original, sp_str_lit(".tmp/unlinked_cwd_test"));
+  sp_str_t sandbox = sp_fs_join_path(ut.mem, original, sp_str_lit(".tmp/unlinked_cwd_test"));
   sp_fs_remove_dir(sandbox);
   ASSERT_EQ(sp_fs_create_dir(sandbox), SP_OK);
 
   ASSERT_EQ(sp_sys_chdir_s(sandbox), 0);
   ASSERT_EQ(sp_fs_remove_dir(sandbox), SP_OK);
 
-  sp_str_t cwd = sp_fs_get_cwd(a);
+  sp_str_t cwd = sp_fs_get_cwd(ut.mem);
 
   // restore cwd before any assertion can fail, so other tests aren't poisoned
   sp_sys_chdir_s(original);

--- a/test/fs/get_exe_path.c
+++ b/test/fs/get_exe_path.c
@@ -1,9 +1,22 @@
 #include "fs.h"
 
-UTEST_F(fs, basic_properties) {
+struct fs_get_exe_path {
+  sp_mem_heap_t* heap;
+  sp_mem_t mem;
+};
+
+UTEST_F_SETUP(fs_get_exe_path) {
+  ut.heap = sp_mem_heap_new();
+  ut.mem = sp_mem_heap_as_allocator(ut.heap);
+}
+
+UTEST_F_TEARDOWN(fs_get_exe_path) {
+  sp_mem_heap_destroy(ut.heap);
+}
+
+UTEST_F(fs_get_exe_path, basic_properties) {
   SKIP_ON_WASM()
-  sp_mem_t a = sp_mem_os_new();
-  sp_str_t exe = sp_fs_get_exe_path(a);
+  sp_str_t exe = sp_fs_get_exe_path(ut.mem);
   ASSERT_GT(exe.len, 0);
 
   // normalized: no backslashes
@@ -19,35 +32,29 @@ UTEST_F(fs, basic_properties) {
   ASSERT_GT(name.len, 0);
 }
 
-UTEST_F(fs, is_absolute) {
+UTEST_F(fs_get_exe_path, is_absolute) {
   SKIP_ON_WASM()
-  sp_mem_t a = sp_mem_os_new();
-  sp_str_t exe = sp_fs_get_exe_path(a);
+  sp_str_t exe = sp_fs_get_exe_path(ut.mem);
   // absolute: starts with / on POSIX, or X: on Windows
   bool is_absolute = (exe.data[0] == '/') || (exe.len >= 2 && exe.data[1] == ':');
   ASSERT_TRUE(is_absolute);
 }
 
-UTEST_F(fs, exists_on_disk) {
+UTEST_F(fs_get_exe_path, exists_on_disk) {
   SKIP_ON_WASM()
-  sp_mem_t a = sp_mem_os_new();
-  sp_str_t exe = sp_fs_get_exe_path(a);
+  sp_str_t exe = sp_fs_get_exe_path(ut.mem);
   ASSERT_TRUE(sp_fs_exists(exe));
 }
 
-UTEST_F(fs, is_canonical) {
+UTEST_F(fs_get_exe_path, is_canonical) {
   SKIP_ON_WASM()
-  sp_mem_t a = sp_mem_os_new();
-  sp_str_t exe = sp_fs_get_exe_path(a);
-  sp_str_t canonical = sp_fs_canonicalize_path(a, exe);
+  sp_str_t exe = sp_fs_get_exe_path(ut.mem);
+  sp_str_t canonical = sp_fs_canonicalize_path(ut.mem, exe);
   SP_EXPECT_STR_EQ(canonical, exe);
 }
 
-UTEST_F(fs, no_dotdot) {
+UTEST_F(fs_get_exe_path, no_dotdot) {
   SKIP_ON_WASM()
-  sp_mem_t a = sp_mem_os_new();
-  sp_str_t exe = sp_fs_get_exe_path(a);
+  sp_str_t exe = sp_fs_get_exe_path(ut.mem);
   ASSERT_FALSE(sp_str_contains(exe, sp_str_lit("..")));
 }
-
-

--- a/test/fs/join_path.c
+++ b/test/fs/join_path.c
@@ -6,9 +6,22 @@ typedef struct {
   const c8* expected;
 } join_path_case_t;
 
-UTEST(fs_join_path, cases) {
+struct fs_join_path {
+  sp_mem_heap_t* heap;
+  sp_mem_t mem;
+};
+
+UTEST_F_SETUP(fs_join_path) {
+  ut.heap = sp_mem_heap_new();
+  ut.mem = sp_mem_heap_as_allocator(ut.heap);
+}
+
+UTEST_F_TEARDOWN(fs_join_path) {
+  sp_mem_heap_destroy(ut.heap);
+}
+
+UTEST_F(fs_join_path, cases) {
   SKIP_ON_WASM()
-  sp_mem_t a = sp_mem_os_new();
   join_path_case_t cases[] = {
     { "foo",  "bar",     "foo/bar" },
     { "foo/", "bar",     "foo/bar" },
@@ -24,9 +37,7 @@ UTEST(fs_join_path, cases) {
   };
 
   SP_CARR_FOR(cases, i) {
-    sp_str_t result = sp_fs_join_path(a, sp_str_view(cases[i].a), sp_str_view(cases[i].b));
+    sp_str_t result = sp_fs_join_path(ut.mem, sp_str_view(cases[i].a), sp_str_view(cases[i].b));
     SP_EXPECT_STR_EQ_CSTR(result, cases[i].expected);
   }
 }
-
-

--- a/test/fs/normalize_path.c
+++ b/test/fs/normalize_path.c
@@ -5,9 +5,22 @@ typedef struct {
   const c8* expected;
 } normalize_path_case_t;
 
-UTEST(fs_normalize_path, cases) {
+struct fs_normalize_path {
+  sp_mem_heap_t* heap;
+  sp_mem_t mem;
+};
+
+UTEST_F_SETUP(fs_normalize_path) {
+  ut.heap = sp_mem_heap_new();
+  ut.mem = sp_mem_heap_as_allocator(ut.heap);
+}
+
+UTEST_F_TEARDOWN(fs_normalize_path) {
+  sp_mem_heap_destroy(ut.heap);
+}
+
+UTEST_F(fs_normalize_path, cases) {
   SKIP_ON_WASM()
-  sp_mem_t a = sp_mem_os_new();
   normalize_path_case_t cases[] = {
     { "",                              "" },
     { "foo",                           "foo" },
@@ -26,34 +39,31 @@ UTEST(fs_normalize_path, cases) {
   };
 
   SP_CARR_FOR(cases, i) {
-    sp_str_t result = sp_fs_normalize_path(a, sp_str_view(cases[i].input));
+    sp_str_t result = sp_fs_normalize_path(ut.mem, sp_str_view(cases[i].input));
     SP_EXPECT_STR_EQ_CSTR(result, cases[i].expected);
   }
 }
 
-UTEST(fs_normalize_path, preserves_dotdot) {
+UTEST_F(fs_normalize_path, preserves_dotdot) {
   SKIP_ON_WASM()
-  sp_mem_t a = sp_mem_os_new();
   SP_EXPECT_STR_EQ_CSTR(
-    sp_fs_normalize_path(a, sp_str_lit("a\\b\\..\\c")),
+    sp_fs_normalize_path(ut.mem, sp_str_lit("a\\b\\..\\c")),
     "a/b/../c"
   );
 }
 
-UTEST(fs_normalize_path, preserves_dot) {
+UTEST_F(fs_normalize_path, preserves_dot) {
   SKIP_ON_WASM()
-  sp_mem_t a = sp_mem_os_new();
   SP_EXPECT_STR_EQ_CSTR(
-    sp_fs_normalize_path(a, sp_str_lit("a\\.\\b")),
+    sp_fs_normalize_path(ut.mem, sp_str_lit("a\\.\\b")),
     "a/./b"
   );
 }
 
-UTEST(fs_normalize_path, nonexistent_path) {
+UTEST_F(fs_normalize_path, nonexistent_path) {
   SKIP_ON_WASM()
-  sp_mem_t a = sp_mem_os_new();
   SP_EXPECT_STR_EQ_CSTR(
-    sp_fs_normalize_path(a, sp_str_lit("C:\\no\\such\\path\\file.txt")),
+    sp_fs_normalize_path(ut.mem, sp_str_lit("C:\\no\\such\\path\\file.txt")),
     "C:/no/such/path/file.txt"
   );
 }

--- a/test/fs/replace_ext.c
+++ b/test/fs/replace_ext.c
@@ -6,9 +6,22 @@ typedef struct {
   const c8* expected;
 } replace_ext_case_t;
 
-UTEST(fs_replace_ext, cases) {
+struct fs_replace_ext {
+  sp_mem_heap_t* heap;
+  sp_mem_t mem;
+};
+
+UTEST_F_SETUP(fs_replace_ext) {
+  ut.heap = sp_mem_heap_new();
+  ut.mem = sp_mem_heap_as_allocator(ut.heap);
+}
+
+UTEST_F_TEARDOWN(fs_replace_ext) {
+  sp_mem_heap_destroy(ut.heap);
+}
+
+UTEST_F(fs_replace_ext, cases) {
   SKIP_ON_WASM()
-  sp_mem_t a = sp_mem_os_new();
   replace_ext_case_t cases[] = {
     { "foo.c",       "o",   "foo.c.o" },
     { "foo.c",       "",    "foo." },
@@ -19,9 +32,7 @@ UTEST(fs_replace_ext, cases) {
   };
 
   SP_CARR_FOR(cases, i) {
-    sp_str_t result = sp_fs_replace_ext(a, sp_str_view(cases[i].path), sp_str_view(cases[i].ext));
+    sp_str_t result = sp_fs_replace_ext(ut.mem, sp_str_view(cases[i].path), sp_str_view(cases[i].ext));
     SP_EXPECT_STR_EQ_CSTR(result, cases[i].expected);
   }
 }
-
-

--- a/test/fs/system_paths.c
+++ b/test/fs/system_paths.c
@@ -14,24 +14,34 @@ static void assert_normalized(s32* utest_result, sp_str_t path, const c8* label)
   }
 }
 
-UTEST(fs_system_paths, nonempty) {
-  SKIP_ON_WASM()
-  sp_mem_t a = sp_mem_os_new();
-  ASSERT_GT(sp_fs_get_storage_path(a).len, 0);
-  ASSERT_GT(sp_fs_get_config_path(a).len, 0);
+struct fs_system_paths {
+  sp_mem_heap_t* heap;
+  sp_mem_t mem;
+};
+
+UTEST_F_SETUP(fs_system_paths) {
+  ut.heap = sp_mem_heap_new();
+  ut.mem = sp_mem_heap_as_allocator(ut.heap);
 }
 
-UTEST(fs_system_paths, storage_path_normalized) {
+UTEST_F_TEARDOWN(fs_system_paths) {
+  sp_mem_heap_destroy(ut.heap);
+}
+
+UTEST_F(fs_system_paths, nonempty) {
   SKIP_ON_WASM()
-  sp_mem_t a = sp_mem_os_new();
-  sp_str_t path = sp_fs_get_storage_path(a);
+  ASSERT_GT(sp_fs_get_storage_path(ut.mem).len, 0);
+  ASSERT_GT(sp_fs_get_config_path(ut.mem).len, 0);
+}
+
+UTEST_F(fs_system_paths, storage_path_normalized) {
+  SKIP_ON_WASM()
+  sp_str_t path = sp_fs_get_storage_path(ut.mem);
   assert_normalized(&ur, path, "storage_path");
 }
 
-UTEST(fs_system_paths, config_path_normalized) {
+UTEST_F(fs_system_paths, config_path_normalized) {
   SKIP_ON_WASM()
-  sp_mem_t a = sp_mem_os_new();
-  sp_str_t path = sp_fs_get_config_path(a);
+  sp_str_t path = sp_fs_get_config_path(ut.mem);
   assert_normalized(&ur, path, "config_path");
 }
-

--- a/test/process.c
+++ b/test/process.c
@@ -58,7 +58,7 @@ s32 main(s32 num_args, const c8** args) {
   s32 pattern_size = 100;
   s32 pattern_count = 10;
 
-  sp_mem_t mem = sp_mem_os_new();
+  sp_mem_t mem = sp_mem_heap_as_allocator(sp_mem_heap_new());
 
   struct argparse_option options[] = {
     OPT_HELP(),


### PR DESCRIPTION
Now that the heap allocator is in, it's better in a lot of places. Use it. Also cleaned up a few tests which leaked enough memory to push it into the MB range over the whole suite.