### PR TITLE
http: switch to pull based body delivery + factor out utilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ endif
 
 TESTS = amalg app array asset cli etc env format fmon glob ht io math process ps rb str sys thread time mem prompt leak qsort
 BENCHES = glob heap
-EXAMPLES = app array cargo cli format hash_table io zero_copy ls palette post prompt prompt_fancy signal tls wc
+EXAMPLES = app array cargo cli format hash_table io zero_copy ls palette post prompt prompt_fancy serve signal tls wc
 TRIPLES = \
   x86_64-linux-none x86_64-linux-gnu x86_64-linux-musl \
   aarch64-linux-none aarch64-linux-gnu aarch64-linux-musl \

--- a/example/post.c
+++ b/example/post.c
@@ -14,19 +14,6 @@ typedef struct {
 } post_t;
 
 #if defined(SP_TLS_WITH_MBEDTLS)
-static const c8* method_names[] = { "GET", "POST", "PUT", "PATCH", "DELETE" };
-
-static bool method_parse(sp_mem_t mem, sp_str_t str, sp_http_method_t* method) {
-  sp_str_t upper = sp_str_to_upper(mem, str);
-  sp_carr_for(method_names, it) {
-    if (sp_str_equal_cstr(upper, method_names[it])) {
-      *method = (sp_http_method_t)it;
-      return true;
-    }
-  }
-  return false;
-}
-
 sp_cli_result_t post_run(sp_cli_t* cli) {
   post_t* post = sp_cast(post_t*, cli->user_data);
 
@@ -38,6 +25,8 @@ sp_cli_result_t post_run(sp_cli_t* cli) {
   sp_io_file_writer_t file = sp_zero;
   sp_http_response_t response = sp_zero;
   sp_http_error_t err = sp_zero;
+  u32 num_headers = 0;
+  sp_http_header_t* headers = SP_NULLPTR;
 
   sp_http_request_t request = {
     .url = sp_cstr_as_str(post->url),
@@ -58,28 +47,30 @@ sp_cli_result_t post_run(sp_cli_t* cli) {
     request.method = SP_HTTP_POST;
   }
 
-  if (post->method && !method_parse(mem, sp_cstr_as_str(post->method), &request.method)) {
-    result = sp_cli_set_error_c(cli, "method must be one of GET, POST, PUT, PATCH, DELETE");
+  if (post->method && !sp_http_method_parse(sp_str_to_upper(mem, sp_cstr_as_str(post->method)), &request.method)) {
+    result = sp_cli_set_error_c(cli, "method must be one of GET, POST, PUT, PATCH, DELETE, HEAD");
     goto done;
   }
   if (post->type) {
     request.content_type = sp_cstr_as_str(post->type);
   }
 
-  for (u32 it = 0; cli->rest[it]; it++) {
-    if (it >= SP_HTTP_MAX_HEADERS) {
-      result = sp_cli_set_error_c(cli, "too many headers");
-      goto done;
-    }
+  while (cli->rest[num_headers]) num_headers++;
+  headers = sp_alloc_n(mem, sp_http_header_t, num_headers);
+  sp_for(it, num_headers) {
     sp_str_t header = sp_cstr_as_str(cli->rest[it]);
     s32 colon = sp_str_find_c8(header, ':');
     if (colon == SP_STR_NO_MATCH) {
       result = sp_cli_set_error(cli, sp_fmt(mem, "header must be 'Name: Value', got {}", sp_fmt_str(header)).value);
       goto done;
     }
-    request.headers[it].name = sp_str_sub(header, 0, colon);
-    request.headers[it].value = sp_str_trim(sp_str_sub(header, colon + 1, (s32)header.len - colon - 1));
+    headers[it] = (sp_http_header_t) {
+      .name = sp_str_sub(header, 0, colon),
+      .value = sp_str_trim(sp_str_sub(header, colon + 1, (s32)header.len - colon - 1)),
+    };
   }
+  request.headers = headers;
+  request.num_headers = num_headers;
 
   sp_tls_trust_init(&trust, mem);
   if (sp_tls_trust_load(&trust) != SP_HTTP_OK && trust.backend == SP_TLS_BACKEND_ANCHORS) {
@@ -103,7 +94,7 @@ sp_cli_result_t post_run(sp_cli_t* cli) {
   }
 
   if (post->verbose) {
-    sp_log("{} {} ({} bytes)", sp_fmt_cstr(method_names[request.method]), sp_fmt_str(request.url), sp_fmt_uint(request.payload.len));
+    sp_log("{} {} ({} bytes)", sp_fmt_str(sp_http_method_name(request.method)), sp_fmt_str(request.url), sp_fmt_uint(request.payload.len));
   }
 
   err = sp_http_fetch(mem, request, &response);
@@ -135,10 +126,11 @@ sp_cli_result_t post_run(sp_cli_t* cli) {
   }
 
   if (post->verbose && err == SP_HTTP_OK) {
+    sp_str_t content_type = sp_http_headers_find(response.headers, sp_str_lit("content-type"));
     sp_log("status {} ({} bytes, {})",
       sp_fmt_int(response.status),
       sp_fmt_uint(response.body_len),
-      sp_fmt_str(sp_str_empty(response.content_type) ? sp_str_lit("no content type") : response.content_type));
+      sp_fmt_str(sp_str_empty(content_type) ? sp_str_lit("no content type") : content_type));
   }
 
 done:

--- a/example/serve.c
+++ b/example/serve.c
@@ -36,6 +36,8 @@ static void serve_client(serve_t* serve, sp_sys_socket_t client) {
   sp_http_request_head_t request = sp_zero;
   sp_http_body_t body = sp_zero;
   sp_http_method_t method = SP_HTTP_GET;
+  bool known_method = false;
+  sp_str_t target = sp_zero;
   sp_io_dyn_mem_writer_t payload = sp_zero;
   sp_io_dyn_mem_writer_init(scratch.mem, &payload);
 
@@ -46,8 +48,8 @@ static void serve_client(serve_t* serve, sp_sys_socket_t client) {
     goto done;
   }
 
-  bool known_method = sp_http_method_parse(request.method, &method);
-  sp_str_t target = sp_str_copy(scratch.mem, request.target);
+  known_method = sp_http_method_parse(request.method, &method);
+  target = sp_str_copy(scratch.mem, request.target);
 
   if (sp_http_body_read(&reader.base, body, &payload.base, SP_NULLPTR) != SP_HTTP_OK) {
     respond(&writer.base, 400, sp_str_lit("text/plain"), sp_str_lit("bad body\n"));

--- a/example/serve.c
+++ b/example/serve.c
@@ -1,0 +1,150 @@
+#define SP_IMPLEMENTATION
+#include "sp.h"
+#include "sp/sp_cli.h"
+#include "sp/sp_http.h"
+
+#define SERVE_BUFFER_SIZE 16384
+#define SERVE_IO_TIMEOUT_MS 10000
+
+typedef struct {
+  u16       port;
+  const c8* output;
+  s32       exit;
+} serve_t;
+
+static void respond(sp_io_writer_t* writer, s32 status, sp_str_t content_type, sp_str_t body) {
+  sp_http_header_t headers [2];
+  u32 count = 0;
+  if (!sp_str_empty(content_type)) {
+    headers[count++] = (sp_http_header_t) { .name = sp_str_lit("Content-Type"), .value = content_type };
+  }
+  headers[count++] = (sp_http_header_t) { .name = sp_str_lit("Connection"), .value = sp_str_lit("close") };
+  sp_http_response_write(writer, status, headers, count, body);
+}
+
+static void serve_client(serve_t* serve, sp_sys_socket_t client) {
+  sp_mem_arena_marker_t scratch = sp_mem_begin_scratch();
+
+  sp_io_socket_reader_t reader = sp_zero;
+  sp_io_socket_writer_t writer = sp_zero;
+  sp_io_socket_reader_init(&reader, client, SERVE_IO_TIMEOUT_MS);
+  sp_io_socket_writer_init(&writer, client, SERVE_IO_TIMEOUT_MS);
+  u8* buffer = sp_alloc_n(scratch.mem, u8, SERVE_BUFFER_SIZE);
+  sp_io_reader_set_buffer(&reader.base, buffer, SERVE_BUFFER_SIZE);
+
+  sp_str_t head_str = sp_zero;
+  sp_http_request_head_t request = sp_zero;
+  sp_http_body_t body = sp_zero;
+  sp_http_method_t method = SP_HTTP_GET;
+  sp_io_dyn_mem_writer_t payload = sp_zero;
+  sp_io_dyn_mem_writer_init(scratch.mem, &payload);
+
+  if (sp_http_head_read(&reader.base, &head_str) != SP_HTTP_OK ||
+      sp_http_request_head_parse(head_str, &request) != SP_HTTP_OK ||
+      sp_http_body_parse(request.headers, &body) != SP_HTTP_OK) {
+    respond(&writer.base, 400, sp_str_lit("text/plain"), sp_str_lit("bad request\n"));
+    goto done;
+  }
+
+  bool known_method = sp_http_method_parse(request.method, &method);
+  sp_str_t target = sp_str_copy(scratch.mem, request.target);
+
+  if (sp_http_body_read(&reader.base, body, &payload.base, SP_NULLPTR) != SP_HTTP_OK) {
+    respond(&writer.base, 400, sp_str_lit("text/plain"), sp_str_lit("bad body\n"));
+    goto done;
+  }
+
+  if (!known_method) {
+    respond(&writer.base, 501, sp_zero_s(sp_str_t), sp_zero_s(sp_str_t));
+    goto done;
+  }
+
+  sp_log("{} {}", sp_fmt_str(sp_http_method_name(method)), sp_fmt_str(target));
+
+  if (method == SP_HTTP_GET && sp_str_equal_cstr(target, "/")) {
+    respond(&writer.base, 200, sp_str_lit("text/plain"), sp_str_lit("sp serve: POST /screenshot to save a capture\n"));
+  }
+  else if (method == SP_HTTP_POST && sp_str_equal_cstr(target, "/screenshot")) {
+    sp_str_t data = sp_io_dyn_mem_writer_as_str(&payload);
+    sp_str_t path = sp_cstr_as_str(serve->output);
+    if (sp_fs_create_file_str(path, data) != SP_OK) {
+      respond(&writer.base, 500, sp_str_lit("text/plain"), sp_str_lit("could not write capture\n"));
+      goto done;
+    }
+    sp_str_t reply = sp_fmt(scratch.mem, "{{\"path\": \"{}\", \"bytes\": {}}}\n", sp_fmt_str(path), sp_fmt_uint(data.len)).value;
+    respond(&writer.base, 200, sp_str_lit("application/json"), reply);
+  }
+  else {
+    respond(&writer.base, 404, sp_str_lit("text/plain"), sp_str_lit("not found\n"));
+  }
+
+done:
+  sp_mem_end_scratch(scratch);
+  sp_sys_socket_close(client);
+}
+
+sp_cli_result_t serve_run(sp_cli_t* cli) {
+  serve_t* serve = sp_cast(serve_t*, cli->user_data);
+
+  sp_sys_socket_t listener = SP_SYS_INVALID_SOCKET;
+  if (sp_sys_socket_open(&listener, (sp_sys_handle_desc_t) { SP_SYS_BLOCKING }) != SP_OK ||
+      sp_sys_socket_reuse_addr(listener) != SP_OK ||
+      sp_sys_socket_bind(listener, (sp_sys_ipv4_t) { .octets = { 127, 0, 0, 1 }, .port = serve->port }) != SP_OK ||
+      sp_sys_socket_listen(listener, 4) != SP_OK) {
+    sp_log("could not listen on 127.0.0.1:{}", sp_fmt_uint(serve->port));
+    serve->exit = 1;
+    return SP_CLI_OK;
+  }
+
+  u16 port = 0;
+  sp_sys_socket_local_port(listener, &port);
+  sp_log("listening on http://127.0.0.1:{}", sp_fmt_uint(port));
+
+  for (;;) {
+    sp_sys_socket_t client = SP_SYS_INVALID_SOCKET;
+    if (sp_sys_socket_accept(listener, (sp_sys_handle_desc_t) { SP_SYS_NONBLOCKING }, &client) != SP_OK) break;
+    serve_client(serve, client);
+  }
+
+  sp_sys_socket_close(listener);
+  return SP_CLI_OK;
+}
+
+s32 run(s32 num_args, const c8** args) {
+  serve_t serve = {
+    .output = "screenshot.bin",
+  };
+
+  sp_cli_cmd_t root = {
+    .name = "serve",
+    .summary = "Serve a tiny HTTP remote control API",
+    .opts = {
+      {
+        .brief = 'p',
+        .name = "port",
+        .kind = SP_CLI_OPT_U16,
+        .summary = "Port to listen on; defaults to an OS-assigned port",
+        .placeholder = "PORT",
+        .ptr = &serve.port,
+      },
+      {
+        .brief = 'o',
+        .name = "output",
+        .kind = SP_CLI_OPT_CSTR,
+        .summary = "File to write POST /screenshot payloads to",
+        .placeholder = "FILE",
+        .ptr = &serve.output,
+      },
+    },
+    .handler = serve_run,
+  };
+
+  s32 code = sp_cli_main((sp_cli_desc_t) {
+    .root = &root,
+    .args = args,
+    .num_args = num_args,
+    .user_data = &serve,
+  });
+  return code ? code : serve.exit;
+}
+SP_MAIN(run)

--- a/example/tls.c
+++ b/example/tls.c
@@ -9,6 +9,14 @@ typedef struct {
   s32       exit;
 } tls_t;
 
+static sp_str_t output_name(sp_mem_t mem, sp_http_url_t url, const c8* override) {
+  if (override) return sp_cstr_as_str(override);
+  sp_str_t name = sp_fs_get_name(url.path);
+  if (sp_str_empty(name) || sp_str_equal_cstr(name, "/")) return sp_str_lit("index.html");
+  return sp_str_copy(mem, name);
+}
+
+#if defined(SP_TLS_WITH_MBEDTLS)
 static const c8* backend_name(sp_tls_backend_t backend) {
   switch (backend) {
     case SP_TLS_BACKEND_ANCHORS:   return "anchors (mbedTLS verifies extracted roots)";
@@ -18,14 +26,6 @@ static const c8* backend_name(sp_tls_backend_t backend) {
   return "unknown";
 }
 
-static sp_str_t output_name(sp_mem_t mem, sp_http_url_t url, const c8* override) {
-  if (override) return sp_cstr_as_str(override);
-  sp_str_t name = sp_fs_get_name(url.path);
-  if (sp_str_empty(name) || sp_str_equal_cstr(name, "/")) return sp_str_lit("index.html");
-  return sp_str_copy(mem, name);
-}
-
-#if defined(SP_TLS_WITH_MBEDTLS)
 sp_cli_result_t tls_run(sp_cli_t* cli) {
   tls_t* tls = sp_cast(tls_t*, cli->user_data);
 
@@ -107,19 +107,7 @@ done:
 #else
 sp_cli_result_t tls_run(sp_cli_t* cli) {
   tls_t* tls = sp_cast(tls_t*, cli->user_data);
-
-  sp_mem_heap_t* heap = sp_mem_heap_new();
-  sp_mem_t mem = sp_mem_heap_as_allocator(heap);
-
-  sp_tls_trust_t trust = sp_zero;
-  sp_tls_trust_init(&trust, mem);
-  sp_tls_trust_load(&trust);
-
-  sp_log("backend: {}", sp_fmt_cstr(backend_name(trust.backend)));
   sp_log("mbedTLS not compiled in for this target; cannot fetch {}", sp_fmt_cstr(tls->url));
-
-  sp_tls_trust_free(&trust);
-  sp_mem_heap_destroy(heap);
   return SP_CLI_OK;
 }
 #endif

--- a/sp/sp_http.h
+++ b/sp/sp_http.h
@@ -7,10 +7,6 @@
   #define SP_HTTP_SOCKETS
 #endif
 
-struct mbedtls_x509_crt;
-struct mbedtls_ssl_config;
-struct mbedtls_ssl_context;
-
 typedef enum {
   SP_HTTP_OK = 0,
   SP_HTTP_ERR_NO_STORE,
@@ -29,16 +25,11 @@ typedef enum {
   SP_HTTP_ERR_PROXY,
 } sp_http_error_t;
 
-// @http
 #define SP_HTTP_DEFAULT_REDIRECTS          16
 #define SP_HTTP_DEFAULT_CONNECT_TIMEOUT_MS 30000
 #define SP_HTTP_DEFAULT_IO_TIMEOUT_MS      60000
 #define SP_HTTP_TIMEOUT_INFINITE           0xffffffffu
 #define SP_HTTP_MAX_ADDRS                  16
-
-#ifndef SP_HTTP_MAX_HEADERS
-  #define SP_HTTP_MAX_HEADERS 16
-#endif
 
 typedef struct {
   sp_str_t scheme;
@@ -54,12 +45,50 @@ typedef enum {
   SP_HTTP_PUT,
   SP_HTTP_PATCH,
   SP_HTTP_DELETE,
+  SP_HTTP_HEAD,
 } sp_http_method_t;
 
 typedef struct {
   sp_str_t name;
   sp_str_t value;
 } sp_http_header_t;
+
+typedef enum {
+  SP_HTTP_BODY_NONE,
+  SP_HTTP_BODY_LENGTH,
+  SP_HTTP_BODY_CHUNKED,
+  SP_HTTP_BODY_EOF,
+} sp_http_body_kind_t;
+
+typedef struct {
+  sp_http_body_kind_t kind;
+  u64                 length;
+} sp_http_body_t;
+
+typedef struct {
+  sp_str_t method;
+  sp_str_t target;
+  sp_str_t headers;
+} sp_http_request_head_t;
+
+typedef struct {
+  s32      status;
+  sp_str_t headers;
+} sp_http_response_head_t;
+
+typedef struct {
+  sp_str_t rest;
+} sp_http_headers_it_t;
+
+typedef struct {
+  sp_io_reader_t      base;
+  sp_io_reader_t*     inner;
+  sp_http_body_kind_t kind;
+  u64                 remaining;
+  bool                line_pending;
+  bool                done;
+  sp_http_error_t     err;
+} sp_http_body_reader_t;
 
 typedef enum {
   SP_HTTP_ADDR_V4,
@@ -71,8 +100,6 @@ typedef struct {
   u8                  data [16];
 } sp_http_addr_t;
 
-// Resolves a bare hostname to addresses; IP literals are handled before the
-// resolver is consulted, so implementations only ever see real names.
 typedef sp_http_error_t (*sp_http_resolve_fn)(void* user_data, sp_str_t host, u32 timeout_ms, sp_http_addr_t* addrs, u32 capacity, u32* count);
 
 typedef struct {
@@ -80,8 +107,9 @@ typedef struct {
   void*              user_data;
 } sp_http_resolver_t;
 
-
-// @tls
+/////////
+// TLS //
+/////////
 typedef struct sp_tls sp_tls_t;
 
 struct sp_tls {
@@ -91,51 +119,6 @@ struct sp_tls {
   sp_io_writer_t* writer;
 };
 
-typedef enum {
-  SP_TLS_BACKEND_NONE,
-  SP_TLS_BACKEND_ANCHORS,
-  SP_TLS_BACKEND_OS_VERIFY,
-} sp_tls_backend_t;
-
-typedef struct {
-  sp_tls_backend_t         backend;
-  struct mbedtls_x509_crt* anchors;
-  u32                      loaded;
-  u32                      skipped;
-  sp_mem_t                 mem;
-} sp_tls_trust_t;
-
-typedef struct {
-  sp_str_t hostname;
-} sp_tls_verify_t;
-
-typedef s32 (*sp_tls_verify_fn)(void* user_data, struct mbedtls_x509_crt* crt, s32 depth, u32* flags);
-
-SP_API sp_tls_backend_t sp_tls_native_backend(void);
-
-
-SP_API sp_http_error_t  sp_tls_trust_init(sp_tls_trust_t* trust, sp_mem_t mem);
-SP_API void             sp_tls_trust_free(sp_tls_trust_t* trust);
-SP_API sp_http_error_t  sp_tls_trust_load(sp_tls_trust_t* trust);
-
-
-SP_API sp_http_error_t  sp_tls_load_windows(struct mbedtls_x509_crt* chain, sp_mem_t mem, u32* loaded, u32* skipped);
-SP_API sp_http_error_t  sp_tls_load_unix(struct mbedtls_x509_crt* chain, sp_mem_t mem, u32* loaded, u32* skipped);
-SP_API sp_http_error_t  sp_tls_load_pem(struct mbedtls_x509_crt* chain, sp_str_t path, u32* loaded, u32* skipped);
-
-
-SP_API sp_http_error_t  sp_tls_conf_apply(const sp_tls_trust_t* trust, struct mbedtls_ssl_config* conf);
-SP_API sp_http_error_t  sp_tls_ssl_attach(const sp_tls_trust_t* trust, struct mbedtls_ssl_context* ssl, sp_tls_verify_t* verify, sp_str_t hostname);
-
-
-SP_API s32              sp_tls_verify_cb(void* user_data, struct mbedtls_x509_crt* crt, s32 depth, u32* flags);
-SP_API sp_http_error_t  sp_tls_macos_eval(const struct mbedtls_x509_crt* chain, sp_str_t hostname);
-SP_API sp_http_error_t  sp_tls_windows_eval(const struct mbedtls_x509_crt* chain, sp_str_t hostname);
-
-
-SP_API sp_http_error_t  sp_tls_chain_der(const struct mbedtls_x509_crt* chain, sp_mem_t mem, sp_mem_slice_t** ders, u32* count);
-
-
 #if defined(SP_TLS_WITH_MBEDTLS)
 #include <mbedtls/x509_crt.h>
 #include <mbedtls/ssl.h>
@@ -143,6 +126,24 @@ SP_API sp_http_error_t  sp_tls_chain_der(const struct mbedtls_x509_crt* chain, s
 #include <mbedtls/entropy.h>
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/error.h>
+
+typedef enum {
+  SP_TLS_BACKEND_NONE,
+  SP_TLS_BACKEND_ANCHORS,
+  SP_TLS_BACKEND_OS_VERIFY,
+} sp_tls_backend_t;
+
+typedef struct {
+  sp_tls_backend_t  backend;
+  mbedtls_x509_crt* anchors;
+  u32               loaded;
+  u32               skipped;
+  sp_mem_t          mem;
+} sp_tls_trust_t;
+
+typedef struct {
+  sp_str_t hostname;
+} sp_tls_verify_t;
 
 typedef struct sp_tls_mbedtls sp_tls_mbedtls_t;
 
@@ -172,38 +173,58 @@ struct sp_tls_mbedtls {
   sp_tls_mbedtls_writer_t  writer;
 };
 
+SP_API sp_http_error_t  sp_tls_trust_init(sp_tls_trust_t* trust, sp_mem_t mem);
+SP_API void             sp_tls_trust_free(sp_tls_trust_t* trust);
+SP_API sp_http_error_t  sp_tls_trust_load(sp_tls_trust_t* trust);
+SP_API sp_http_error_t  sp_tls_load_pem(mbedtls_x509_crt* chain, sp_str_t path, u32* loaded, u32* skipped);
 SP_API void             sp_tls_mbedtls_init(sp_tls_mbedtls_t* tls, const sp_tls_trust_t* trust);
 #endif
 
-
-// @http
 typedef struct {
-  sp_str_t           url;
-  sp_tls_t*          tls;
-  sp_http_resolver_t resolver;
-  sp_io_writer_t*    sink;
-  sp_http_method_t   method;
-  sp_str_t           payload;
-  sp_str_t           content_type;
-  sp_http_header_t   headers[SP_HTTP_MAX_HEADERS];
-  u32                max_redirects;
-  sp_str_t           proxy;
-  bool               no_proxy;
-  u32                connect_timeout_ms;
-  u32                io_timeout_ms;
+  sp_str_t                url;
+  sp_tls_t*               tls;
+  sp_http_resolver_t      resolver;
+  sp_io_writer_t*         sink;
+  sp_http_method_t        method;
+  sp_str_t                payload;
+  sp_str_t                content_type;
+  const sp_http_header_t* headers;
+  u32                     num_headers;
+  u32                     max_redirects;
+  sp_str_t                proxy;
+  bool                    no_proxy;
+  u32                     connect_timeout_ms;
+  u32                     io_timeout_ms;
 } sp_http_request_t;
 
 typedef struct {
   s32      status;
   u64      body_len;
   sp_str_t url;
-  sp_str_t content_type;
-  sp_str_t location;
+  sp_str_t headers;
 } sp_http_response_t;
 
-SP_API bool               sp_http_url_parse(sp_str_t url, sp_http_url_t* out);
-SP_API sp_http_resolver_t sp_http_resolver_default(void);
-SP_API sp_http_error_t    sp_http_fetch(sp_mem_t mem, sp_http_request_t request, sp_http_response_t* response);
+SP_API bool                 sp_http_url_parse(sp_str_t url, sp_http_url_t* out);
+SP_API sp_str_t             sp_http_method_name(sp_http_method_t method);
+SP_API bool                 sp_http_method_parse(sp_str_t name, sp_http_method_t* out);
+SP_API sp_str_t             sp_http_status_reason(s32 status);
+SP_API sp_http_headers_it_t sp_http_headers_it(sp_str_t headers);
+SP_API bool                 sp_http_headers_it_next(sp_http_headers_it_t* it, sp_http_header_t* out);
+SP_API sp_str_t             sp_http_headers_find(sp_str_t headers, sp_str_t name);
+SP_API bool                 sp_http_headers_has(sp_str_t headers, sp_str_t name);
+SP_API sp_http_error_t      sp_http_headers_check(const sp_http_header_t* headers, u32 count);
+SP_API sp_http_error_t      sp_http_request_head_parse(sp_str_t head, sp_http_request_head_t* out);
+SP_API sp_http_error_t      sp_http_response_head_parse(sp_str_t head, sp_http_response_head_t* out);
+SP_API sp_http_error_t      sp_http_body_parse(sp_str_t headers, sp_http_body_t* out);
+SP_API sp_http_error_t      sp_http_response_body_parse(s32 status, bool head_request, sp_str_t headers, sp_http_body_t* out);
+SP_API sp_http_error_t      sp_http_head_read(sp_io_reader_t* reader, sp_str_t* head);
+SP_API void                 sp_http_body_reader_init(sp_http_body_reader_t* r, sp_io_reader_t* inner, sp_http_body_t body);
+SP_API sp_http_error_t      sp_http_body_read(sp_io_reader_t* reader, sp_http_body_t body, sp_io_writer_t* sink, u64* len);
+SP_API sp_http_error_t      sp_http_request_head_write(sp_io_writer_t* writer, sp_str_t method, sp_str_t target, const sp_http_header_t* headers, u32 count);
+SP_API sp_http_error_t      sp_http_response_head_write(sp_io_writer_t* writer, s32 status, const sp_http_header_t* headers, u32 count);
+SP_API sp_http_error_t      sp_http_response_write(sp_io_writer_t* writer, s32 status, const sp_http_header_t* headers, u32 count, sp_str_t body);
+SP_API sp_http_resolver_t   sp_http_resolver_default(void);
+SP_API sp_http_error_t      sp_http_fetch(sp_mem_t mem, sp_http_request_t request, sp_http_response_t* response);
 
 #endif
 
@@ -216,25 +237,16 @@ SP_API sp_http_error_t    sp_http_fetch(sp_mem_t mem, sp_http_request_t request,
 #define SP_HTTP_IMPL_H
 
 typedef struct {
-  s32      status;
-  sp_str_t location;
-  sp_str_t content_type;
-  bool     chunked;
-  bool     has_length;
-  u64      length;
-} sp_http_head_t;
-
-typedef struct {
   sp_http_url_t           url;
   bool                    absolute_form;
   sp_http_method_t        method;
   sp_str_t                payload;
   sp_str_t                content_type;
   const sp_http_header_t* headers;
+  u32                     num_headers;
   bool                    strip_auth;
 } sp_http_wire_t;
 
-// @http
 SP_PRIVATE bool            sp_http_ci_equal(sp_str_t a, sp_str_t b);
 SP_PRIVATE bool            sp_http_ci_contains(sp_str_t haystack, sp_str_t needle);
 SP_PRIVATE sp_str_t        sp_http_str_tail(sp_str_t str, s32 from);
@@ -246,7 +258,10 @@ SP_PRIVATE bool            sp_http_addr_parse(sp_str_t host, sp_http_addr_t* out
 SP_PRIVATE bool            sp_http_url_host_ok(sp_str_t host);
 SP_PRIVATE bool            sp_http_url_port_ok(sp_str_t port);
 SP_PRIVATE bool            sp_http_url_path_ok(sp_str_t path);
-SP_PRIVATE sp_http_error_t sp_http_parse_head(sp_str_t head, sp_http_head_t* out);
+SP_PRIVATE bool            sp_http_token_ok(sp_str_t token);
+SP_PRIVATE bool            sp_http_header_value_ok(sp_str_t value);
+SP_PRIVATE sp_http_error_t sp_http_status_line_parse(sp_str_t line, s32* status);
+SP_PRIVATE sp_http_error_t sp_http_header_lines_check(sp_str_t lines);
 SP_PRIVATE bool            sp_http_location_is_absolute(sp_str_t location);
 SP_PRIVATE sp_str_t        sp_http_resolve_url(sp_mem_t mem, sp_http_url_t base, sp_str_t location);
 SP_PRIVATE bool            sp_http_no_proxy_match(sp_str_t host, sp_str_t no_proxy);
@@ -255,13 +270,16 @@ SP_PRIVATE sp_str_t        sp_http_env_either(const c8* lower, const c8* upper);
 SP_PRIVATE sp_str_t        sp_http_proxy_from_env(sp_http_url_t url);
 SP_PRIVATE sp_http_error_t sp_http_map_io(sp_err_t err, sp_http_error_t fallback);
 SP_PRIVATE u32             sp_http_timeout_ms(u32 requested, u32 fallback);
-SP_PRIVATE sp_http_error_t sp_http_read_head(sp_io_reader_t* reader, sp_str_t* head);
 SP_PRIVATE sp_http_error_t sp_http_read_line(sp_io_reader_t* reader, sp_str_t* line);
-SP_PRIVATE sp_http_error_t sp_http_copy_n(sp_io_reader_t* reader, sp_io_writer_t* body, u64 n, u64* written);
-SP_PRIVATE sp_http_error_t sp_http_read_body(sp_io_reader_t* reader, sp_http_head_t head, sp_io_writer_t* body, u64* written);
-SP_PRIVATE sp_str_t        sp_http_method_name(sp_http_method_t method);
-SP_PRIVATE bool            sp_http_headers_have(const sp_http_header_t* headers, sp_str_t name);
-SP_PRIVATE sp_http_error_t sp_http_headers_check(const sp_http_header_t* headers);
+SP_PRIVATE sp_http_error_t sp_http_chunk_begin(sp_http_body_reader_t* r);
+SP_PRIVATE sp_err_t        sp_http_body_reader_advance(sp_http_body_reader_t* r, void* dst, u64 size, u64* moved);
+SP_PRIVATE sp_err_t        sp_http_body_reader_read(sp_io_reader_t* reader, void* ptr, u64 size, u64* bytes_read);
+SP_PRIVATE sp_err_t        sp_http_body_reader_discard(sp_io_reader_t* reader, u64 n, u64* discarded);
+SP_PRIVATE bool            sp_http_header_list_have(const sp_http_header_t* headers, u32 count, sp_str_t name);
+SP_PRIVATE bool            sp_http_headers_reserved(const sp_http_header_t* headers, u32 count);
+SP_PRIVATE sp_http_error_t sp_http_header_write(sp_io_writer_t* writer, sp_http_header_t header);
+SP_PRIVATE sp_http_error_t sp_http_headers_write(sp_io_writer_t* writer, const sp_http_header_t* headers, u32 count);
+SP_PRIVATE sp_http_error_t sp_http_response_head_io(sp_io_writer_t* writer, s32 status, const sp_http_header_t* headers, u32 count);
 SP_PRIVATE sp_str_t        sp_http_build_request(sp_mem_t mem, sp_http_wire_t wire);
 SP_PRIVATE bool            sp_http_proxy_url_parse(sp_mem_t mem, sp_str_t proxy, sp_http_url_t* out);
 
@@ -278,13 +296,14 @@ SP_PRIVATE void            sp_http_conn_close(sp_http_conn_t* conn);
 #endif
 
 #if defined(SP_TLS_WITH_MBEDTLS)
-// @tls
-SP_PRIVATE u32             sp_tls_chain_count(const struct mbedtls_x509_crt* chain);
-#if defined(SP_WIN32)
-// PCCERT_CONTEXT spelled out; wincrypt.h isn't in scope until the implementation
-SP_PRIVATE bool            sp_tls_win32_server_auth(const struct _CERT_CONTEXT* ctx);
-#endif
-
+SP_PRIVATE sp_tls_backend_t sp_tls_native_backend(void);
+SP_PRIVATE u32             sp_tls_chain_count(const mbedtls_x509_crt* chain);
+SP_PRIVATE sp_http_error_t sp_tls_load_unix(mbedtls_x509_crt* chain, u32* loaded, u32* skipped);
+SP_PRIVATE sp_http_error_t sp_tls_conf_apply(const sp_tls_trust_t* trust, mbedtls_ssl_config* conf);
+SP_PRIVATE sp_http_error_t sp_tls_ssl_attach(const sp_tls_trust_t* trust, mbedtls_ssl_context* ssl, sp_tls_verify_t* verify, sp_str_t hostname);
+SP_PRIVATE s32             sp_tls_verify_cb(void* user_data, mbedtls_x509_crt* crt, s32 depth, u32* flags);
+SP_PRIVATE sp_http_error_t sp_tls_macos_eval(const mbedtls_x509_crt* chain, sp_str_t hostname);
+SP_PRIVATE sp_http_error_t sp_tls_windows_eval(const mbedtls_x509_crt* chain, sp_str_t hostname);
 SP_PRIVATE sp_http_error_t sp_tls_mbedtls_open(sp_tls_t* base, sp_sys_socket_t socket, sp_str_t hostname, u32 io_timeout_ms);
 SP_PRIVATE void            sp_tls_mbedtls_close(sp_tls_t* base);
 SP_PRIVATE sp_http_error_t sp_tls_mbedtls_handshake(sp_tls_mbedtls_t* tls, sp_str_t hostname);
@@ -300,21 +319,6 @@ SP_PRIVATE sp_err_t        sp_tls_mbedtls_write(sp_io_writer_t* writer, const vo
 #ifndef SP_HTTP_C
 #if defined(SP_HTTP_IMPLEMENTATION)
 #define SP_HTTP_C
-
-sp_tls_backend_t sp_tls_native_backend(void) {
-#if defined(SP_WIN32)
-  return SP_TLS_BACKEND_OS_VERIFY;
-#elif defined(SP_MACOS) && defined(SP_TLS_MACOS_SECTRUST)
-  return SP_TLS_BACKEND_OS_VERIFY;
-#elif defined(SP_MACOS)
-  // If you didn't compile in SecTrust, fail here instead of at runtime
-  return SP_TLS_BACKEND_NONE;
-#elif defined(SP_LINUX)
-  return SP_TLS_BACKEND_ANCHORS;
-#else
-  return SP_TLS_BACKEND_NONE;
-#endif
-}
 
 SP_PRIVATE bool sp_http_ci_equal(sp_str_t a, sp_str_t b) {
   if (a.len != b.len) return false;
@@ -549,55 +553,241 @@ bool sp_http_url_parse(sp_str_t url, sp_http_url_t* out) {
   return sp_http_url_host_ok(out->host) && sp_http_url_port_ok(out->port) && sp_http_url_path_ok(out->path);
 }
 
+SP_PRIVATE bool sp_http_token_ok(sp_str_t token) {
+  if (sp_str_empty(token)) return false;
+  sp_for(it, token.len) {
+    u8 c = (u8)token.data[it];
+    bool tchar =
+      (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
+      c == '!' || c == '#' || c == '$' || c == '%' || c == '&' || c == '\'' ||
+      c == '*' || c == '+' || c == '-' || c == '.' || c == '^' || c == '_' ||
+      c == '`' || c == '|' || c == '~';
+    if (!tchar) return false;
+  }
+  return true;
+}
 
-SP_PRIVATE sp_http_error_t sp_http_parse_head(sp_str_t head, sp_http_head_t* out) {
-  *out = sp_zero_s(sp_http_head_t);
+SP_PRIVATE bool sp_http_header_value_ok(sp_str_t value) {
+  sp_for(it, value.len) {
+    u8 c = (u8)value.data[it];
+    if ((c < 0x20 && c != '\t') || c == 0x7f) return false;
+  }
+  return true;
+}
 
-  sp_str_t rest = head;
-  bool first = true;
-  for (;;) {
+SP_PRIVATE sp_http_error_t sp_http_status_line_parse(sp_str_t line, s32* status) {
+  if (!sp_str_starts_with(line, sp_str_lit("HTTP/"))) return SP_HTTP_ERR_PROTOCOL;
+  s32 sp1 = sp_str_find_c8(line, ' ');
+  if (sp1 == SP_STR_NO_MATCH) return SP_HTTP_ERR_PROTOCOL;
+  sp_str_t after = sp_str_trim_left(sp_http_str_tail(line, sp1 + 1));
+  s32 sp2 = sp_str_find_c8(after, ' ');
+  sp_str_t code = sp2 == SP_STR_NO_MATCH ? after : sp_str_sub(after, 0, sp2);
+  u32 value = 0;
+  if (!sp_parse_u32_ex(code, &value)) return SP_HTTP_ERR_PROTOCOL;
+  if (value < 100 || value > 599) return SP_HTTP_ERR_PROTOCOL;
+  *status = (s32)value;
+  return SP_HTTP_OK;
+}
+
+SP_PRIVATE sp_http_error_t sp_http_header_lines_check(sp_str_t lines) {
+  sp_str_t rest = lines;
+  while (!sp_str_empty(rest)) {
     s32 nl = sp_str_find(rest, sp_str_lit("\r\n"));
     sp_str_t line = nl == SP_STR_NO_MATCH ? rest : sp_str_sub(rest, 0, nl);
+    rest = nl == SP_STR_NO_MATCH ? sp_zero_s(sp_str_t) : sp_http_str_tail(rest, nl + 2);
 
-    if (first) {
-      if (!sp_str_starts_with(line, sp_str_lit("HTTP/"))) return SP_HTTP_ERR_PROTOCOL;
-      s32 sp1 = sp_str_find_c8(line, ' ');
-      if (sp1 == SP_STR_NO_MATCH) return SP_HTTP_ERR_PROTOCOL;
-      sp_str_t after = sp_str_trim_left(sp_http_str_tail(line, sp1 + 1));
-      s32 sp2 = sp_str_find_c8(after, ' ');
-      sp_str_t code = sp2 == SP_STR_NO_MATCH ? after : sp_str_sub(after, 0, sp2);
-      u32 status = 0;
-      if (!sp_parse_u32_ex(code, &status)) return SP_HTTP_ERR_PROTOCOL;
-      out->status = (s32)status;
-      first = false;
-    }
-    else if (!sp_str_empty(line)) {
-      s32 colon = sp_str_find_c8(line, ':');
-      if (colon != SP_STR_NO_MATCH) {
-        sp_str_t name = sp_str_sub(line, 0, colon);
-        sp_str_t value = sp_str_trim(sp_http_str_tail(line, colon + 1));
-        if (sp_http_ci_equal(name, sp_str_lit("location"))) {
-          out->location = value;
-        }
-        else if (sp_http_ci_equal(name, sp_str_lit("content-type"))) {
-          out->content_type = value;
-        }
-        else if (sp_http_ci_equal(name, sp_str_lit("content-length"))) {
-          u64 length = 0;
-          if (!sp_parse_u64_ex(value, &length)) return SP_HTTP_ERR_PROTOCOL;
-          if (out->has_length && out->length != length) return SP_HTTP_ERR_PROTOCOL;
-          out->has_length = true;
-          out->length = length;
-        }
-        else if (sp_http_ci_equal(name, sp_str_lit("transfer-encoding"))) {
-          out->chunked = sp_http_ci_contains(value, sp_str_lit("chunked"));
-          if (!out->chunked) return SP_HTTP_ERR_PROTOCOL;
-        }
-      }
-    }
+    s32 colon = sp_str_find_c8(line, ':');
+    if (colon == SP_STR_NO_MATCH) return SP_HTTP_ERR_PROTOCOL;
+    if (!sp_http_token_ok(sp_str_sub(line, 0, colon))) return SP_HTTP_ERR_PROTOCOL;
+    if (!sp_http_header_value_ok(sp_http_str_tail(line, colon + 1))) return SP_HTTP_ERR_PROTOCOL;
+  }
+  return SP_HTTP_OK;
+}
 
-    if (nl == SP_STR_NO_MATCH) break;
-    rest = sp_http_str_tail(rest, nl + 2);
+sp_http_headers_it_t sp_http_headers_it(sp_str_t headers) {
+  return (sp_http_headers_it_t) { .rest = headers };
+}
+
+bool sp_http_headers_it_next(sp_http_headers_it_t* it, sp_http_header_t* out) {
+  if (sp_str_empty(it->rest)) return false;
+  s32 nl = sp_str_find(it->rest, sp_str_lit("\r\n"));
+  sp_str_t line = nl == SP_STR_NO_MATCH ? it->rest : sp_str_sub(it->rest, 0, nl);
+  it->rest = nl == SP_STR_NO_MATCH ? sp_zero_s(sp_str_t) : sp_http_str_tail(it->rest, nl + 2);
+
+  s32 colon = sp_str_find_c8(line, ':');
+  if (colon == SP_STR_NO_MATCH || colon == 0) return false;
+  out->name = sp_str_sub(line, 0, colon);
+  out->value = sp_str_trim(sp_http_str_tail(line, colon + 1));
+  return true;
+}
+
+sp_str_t sp_http_headers_find(sp_str_t headers, sp_str_t name) {
+  sp_http_headers_it_t it = sp_http_headers_it(headers);
+  sp_http_header_t header = sp_zero;
+  while (sp_http_headers_it_next(&it, &header)) {
+    if (sp_http_ci_equal(header.name, name)) return header.value;
+  }
+  return sp_zero_s(sp_str_t);
+}
+
+bool sp_http_headers_has(sp_str_t headers, sp_str_t name) {
+  sp_http_headers_it_t it = sp_http_headers_it(headers);
+  sp_http_header_t header = sp_zero;
+  while (sp_http_headers_it_next(&it, &header)) {
+    if (sp_http_ci_equal(header.name, name)) return true;
+  }
+  return false;
+}
+
+sp_http_error_t sp_http_request_head_parse(sp_str_t head, sp_http_request_head_t* out) {
+  *out = sp_zero_s(sp_http_request_head_t);
+  s32 nl = sp_str_find(head, sp_str_lit("\r\n"));
+  sp_str_t line = nl == SP_STR_NO_MATCH ? head : sp_str_sub(head, 0, nl);
+
+  s32 sp1 = sp_str_find_c8(line, ' ');
+  if (sp1 == SP_STR_NO_MATCH) return SP_HTTP_ERR_PROTOCOL;
+  sp_str_t method = sp_str_sub(line, 0, sp1);
+  sp_str_t after = sp_http_str_tail(line, sp1 + 1);
+  s32 sp2 = sp_str_find_c8(after, ' ');
+  if (sp2 == SP_STR_NO_MATCH) return SP_HTTP_ERR_PROTOCOL;
+  sp_str_t target = sp_str_sub(after, 0, sp2);
+  sp_str_t version = sp_http_str_tail(after, sp2 + 1);
+
+  if (!sp_http_token_ok(method)) return SP_HTTP_ERR_PROTOCOL;
+  if (sp_str_empty(target) || !sp_http_url_path_ok(target)) return SP_HTTP_ERR_PROTOCOL;
+  if (!sp_str_equal_cstr(version, "HTTP/1.1") && !sp_str_equal_cstr(version, "HTTP/1.0")) return SP_HTTP_ERR_PROTOCOL;
+
+  out->method = method;
+  out->target = target;
+  if (nl == SP_STR_NO_MATCH) return SP_HTTP_OK;
+  sp_str_t lines = sp_http_str_tail(head, nl + 2);
+  sp_http_error_t err = sp_http_header_lines_check(lines);
+  if (err != SP_HTTP_OK) return err;
+  out->headers = lines;
+  return SP_HTTP_OK;
+}
+
+sp_http_error_t sp_http_response_head_parse(sp_str_t head, sp_http_response_head_t* out) {
+  *out = sp_zero_s(sp_http_response_head_t);
+  s32 nl = sp_str_find(head, sp_str_lit("\r\n"));
+  sp_str_t line = nl == SP_STR_NO_MATCH ? head : sp_str_sub(head, 0, nl);
+  sp_http_error_t err = sp_http_status_line_parse(line, &out->status);
+  if (err != SP_HTTP_OK) return err;
+  if (nl == SP_STR_NO_MATCH) return SP_HTTP_OK;
+  sp_str_t lines = sp_http_str_tail(head, nl + 2);
+  err = sp_http_header_lines_check(lines);
+  if (err != SP_HTTP_OK) return err;
+  out->headers = lines;
+  return SP_HTTP_OK;
+}
+
+sp_http_error_t sp_http_body_parse(sp_str_t headers, sp_http_body_t* out) {
+  *out = sp_zero_s(sp_http_body_t);
+  bool chunked = false;
+  bool has_length = false;
+  u64 length = 0;
+  sp_http_headers_it_t it = sp_http_headers_it(headers);
+  sp_http_header_t header = sp_zero;
+  while (sp_http_headers_it_next(&it, &header)) {
+    if (sp_http_ci_equal(header.name, sp_str_lit("content-length"))) {
+      u64 value = 0;
+      if (!sp_parse_u64_ex(header.value, &value)) return SP_HTTP_ERR_PROTOCOL;
+      if (has_length && length != value) return SP_HTTP_ERR_PROTOCOL;
+      has_length = true;
+      length = value;
+    }
+    else if (sp_http_ci_equal(header.name, sp_str_lit("transfer-encoding"))) {
+      if (!sp_http_ci_contains(header.value, sp_str_lit("chunked"))) return SP_HTTP_ERR_PROTOCOL;
+      chunked = true;
+    }
+  }
+  if (chunked && has_length) return SP_HTTP_ERR_PROTOCOL;
+  if (chunked) {
+    out->kind = SP_HTTP_BODY_CHUNKED;
+  }
+  else if (has_length) {
+    out->kind = SP_HTTP_BODY_LENGTH;
+    out->length = length;
+  }
+  return SP_HTTP_OK;
+}
+
+sp_http_error_t sp_http_response_body_parse(s32 status, bool head_request, sp_str_t headers, sp_http_body_t* out) {
+  *out = sp_zero_s(sp_http_body_t);
+  bool interim = status >= 100 && status <= 199;
+  if (head_request || interim || status == 204 || status == 304) return SP_HTTP_OK;
+  sp_http_error_t err = sp_http_body_parse(headers, out);
+  if (err != SP_HTTP_OK) return err;
+  // a response with no framing headers is delimited by connection close
+  if (out->kind == SP_HTTP_BODY_NONE) out->kind = SP_HTTP_BODY_EOF;
+  return SP_HTTP_OK;
+}
+
+sp_str_t sp_http_method_name(sp_http_method_t method) {
+  switch (method) {
+    case SP_HTTP_GET:    return sp_str_lit("GET");
+    case SP_HTTP_POST:   return sp_str_lit("POST");
+    case SP_HTTP_PUT:    return sp_str_lit("PUT");
+    case SP_HTTP_PATCH:  return sp_str_lit("PATCH");
+    case SP_HTTP_DELETE: return sp_str_lit("DELETE");
+    case SP_HTTP_HEAD:   return sp_str_lit("HEAD");
+  }
+  return sp_zero_s(sp_str_t);
+}
+
+bool sp_http_method_parse(sp_str_t name, sp_http_method_t* out) {
+  const sp_http_method_t methods [] = {
+    SP_HTTP_GET, SP_HTTP_POST, SP_HTTP_PUT, SP_HTTP_PATCH, SP_HTTP_DELETE, SP_HTTP_HEAD,
+  };
+  sp_carr_for(methods, it) {
+    if (sp_str_equal(name, sp_http_method_name(methods[it]))) {
+      *out = methods[it];
+      return true;
+    }
+  }
+  return false;
+}
+
+sp_str_t sp_http_status_reason(s32 status) {
+  switch (status) {
+    case 100: return sp_str_lit("Continue");
+    case 101: return sp_str_lit("Switching Protocols");
+    case 200: return sp_str_lit("OK");
+    case 201: return sp_str_lit("Created");
+    case 202: return sp_str_lit("Accepted");
+    case 204: return sp_str_lit("No Content");
+    case 206: return sp_str_lit("Partial Content");
+    case 301: return sp_str_lit("Moved Permanently");
+    case 302: return sp_str_lit("Found");
+    case 303: return sp_str_lit("See Other");
+    case 304: return sp_str_lit("Not Modified");
+    case 307: return sp_str_lit("Temporary Redirect");
+    case 308: return sp_str_lit("Permanent Redirect");
+    case 400: return sp_str_lit("Bad Request");
+    case 401: return sp_str_lit("Unauthorized");
+    case 403: return sp_str_lit("Forbidden");
+    case 404: return sp_str_lit("Not Found");
+    case 405: return sp_str_lit("Method Not Allowed");
+    case 408: return sp_str_lit("Request Timeout");
+    case 409: return sp_str_lit("Conflict");
+    case 411: return sp_str_lit("Length Required");
+    case 413: return sp_str_lit("Content Too Large");
+    case 414: return sp_str_lit("URI Too Long");
+    case 415: return sp_str_lit("Unsupported Media Type");
+    case 429: return sp_str_lit("Too Many Requests");
+    case 500: return sp_str_lit("Internal Server Error");
+    case 501: return sp_str_lit("Not Implemented");
+    case 502: return sp_str_lit("Bad Gateway");
+    case 503: return sp_str_lit("Service Unavailable");
+    case 504: return sp_str_lit("Gateway Timeout");
+  }
+  return sp_zero_s(sp_str_t);
+}
+
+sp_http_error_t sp_http_headers_check(const sp_http_header_t* headers, u32 count) {
+  sp_for(it, count) {
+    if (!sp_http_token_ok(headers[it].name)) return SP_HTTP_ERR_BAD_CONFIG;
+    if (!sp_http_header_value_ok(headers[it].value)) return SP_HTTP_ERR_BAD_CONFIG;
   }
   return SP_HTTP_OK;
 }
@@ -684,17 +874,14 @@ SP_PRIVATE sp_http_error_t sp_http_map_io(sp_err_t err, sp_http_error_t fallback
   return fallback;
 }
 
-// resolved timeouts: 0 means block forever, matching mbedtls_net_recv_timeout
 SP_PRIVATE u32 sp_http_timeout_ms(u32 requested, u32 fallback) {
   if (requested == SP_HTTP_TIMEOUT_INFINITE) return 0;
   return requested ? requested : fallback;
 }
 
-SP_PRIVATE sp_http_error_t sp_http_read_head(sp_io_reader_t* reader, sp_str_t* head) {
+sp_http_error_t sp_http_head_read(sp_io_reader_t* reader, sp_str_t* head) {
   sp_str_t acc = sp_zero;
   sp_err_t err = sp_io_peek_until(reader, sp_str_lit("\r\n\r\n"), &acc);
-  // a head that outgrows the buffer is the peer's protocol violation, not an
-  // OS failure
   if (err == SP_ERR_IO_NO_SPACE) return SP_HTTP_ERR_PROTOCOL;
   if (err != SP_OK) return sp_http_map_io(err, SP_HTTP_ERR_PROTOCOL);
   sp_io_consume(reader, acc.len);
@@ -712,105 +899,195 @@ SP_PRIVATE sp_http_error_t sp_http_read_line(sp_io_reader_t* reader, sp_str_t* l
   return SP_HTTP_OK;
 }
 
-SP_PRIVATE sp_http_error_t sp_http_copy_n(sp_io_reader_t* reader, sp_io_writer_t* body, u64 n, u64* written) {
-  if (!body) {
-    sp_err_t err = sp_io_discard(reader, n, SP_NULLPTR);
-    if (err != SP_OK) return sp_http_map_io(err, SP_HTTP_ERR_PROTOCOL);
-    return SP_HTTP_OK;
-  }
-
-  sp_io_limit_reader_t limit = sp_zero;
-  sp_io_limit_reader_init(&limit, reader, n);
-  u64 copied = 0;
-  sp_err_t err = sp_io_copy(body, &limit.base, &copied);
-  if (written) *written += copied;
-  if (err != SP_OK) return sp_http_map_io(err, SP_HTTP_ERR_PROTOCOL);
-  if (limit.remaining) return SP_HTTP_ERR_PROTOCOL;
-  return SP_HTTP_OK;
-}
-
-SP_PRIVATE sp_http_error_t sp_http_read_body(sp_io_reader_t* reader, sp_http_head_t head, sp_io_writer_t* body, u64* written) {
-  if (head.status < 200 || head.status == 204 || head.status == 304) {
-    return SP_HTTP_OK;
-  }
-  if (head.chunked) {
-    for (;;) {
-      sp_str_t line = sp_zero;
-      sp_http_error_t err = sp_http_read_line(reader, &line);
-      if (err != SP_HTTP_OK) return err;
-      sp_str_t size_str = line;
-      s32 semi = sp_str_find_c8(size_str, ';');
-      if (semi != SP_STR_NO_MATCH) size_str = sp_str_sub(size_str, 0, semi);
-      size_str = sp_str_trim(size_str);
-
-      u64 size = 0;
-      if (!sp_parse_hex_ex(size_str, &size)) return SP_HTTP_ERR_PROTOCOL;
-      if (size == 0) break;
-
-      sp_http_error_t copy_err = sp_http_copy_n(reader, body, size, written);
-      if (copy_err != SP_HTTP_OK) return copy_err;
-
-      sp_str_t crlf = sp_zero;
-      copy_err = sp_http_read_line(reader, &crlf);
-      if (copy_err != SP_HTTP_OK) return copy_err;
-      if (!sp_str_empty(crlf)) return SP_HTTP_ERR_PROTOCOL;
+SP_PRIVATE sp_http_error_t sp_http_chunk_begin(sp_http_body_reader_t* r) {
+  for (;;) {
+    sp_str_t line = sp_zero;
+    sp_http_error_t err = sp_http_read_line(r->inner, &line);
+    if (err != SP_HTTP_OK) return err;
+    if (r->line_pending) {
+      if (!sp_str_empty(line)) return SP_HTTP_ERR_PROTOCOL;
+      r->line_pending = false;
+      continue;
     }
-    return SP_HTTP_OK;
+    s32 semi = sp_str_find_c8(line, ';');
+    sp_str_t size_str = semi == SP_STR_NO_MATCH ? line : sp_str_sub(line, 0, semi);
+    size_str = sp_str_trim(size_str);
+    u64 size = 0;
+    if (!sp_parse_hex_ex(size_str, &size)) return SP_HTTP_ERR_PROTOCOL;
+    if (size) {
+      r->remaining = size;
+      return SP_HTTP_OK;
+    }
+    for (;;) {
+      sp_str_t trailer = sp_zero;
+      err = sp_http_read_line(r->inner, &trailer);
+      if (err != SP_HTTP_OK) return err;
+      if (sp_str_empty(trailer)) {
+        r->done = true;
+        return SP_HTTP_OK;
+      }
+    }
   }
-  if (head.has_length) {
-    return sp_http_copy_n(reader, body, head.length, written);
+}
+
+SP_PRIVATE sp_err_t sp_http_body_reader_advance(sp_http_body_reader_t* r, void* dst, u64 size, u64* moved) {
+  *moved = 0;
+  if (r->err != SP_HTTP_OK) return SP_ERR_IO;
+  if (r->done) return SP_ERR_IO_EOF;
+
+  switch (r->kind) {
+    case SP_HTTP_BODY_NONE: {
+      r->done = true;
+      return SP_ERR_IO_EOF;
+    }
+    case SP_HTTP_BODY_EOF: {
+      sp_err_t err = dst
+        ? sp_io_read(r->inner, dst, size, moved)
+        : sp_io_discard(r->inner, size, moved);
+      if (err == SP_ERR_IO_EOF) r->done = true;
+      return err;
+    }
+    case SP_HTTP_BODY_LENGTH: {
+      if (!r->remaining) {
+        r->done = true;
+        return SP_ERR_IO_EOF;
+      }
+      u64 n = sp_min(size, r->remaining);
+      sp_err_t err = dst
+        ? sp_io_read(r->inner, dst, n, moved)
+        : sp_io_discard(r->inner, n, moved);
+      r->remaining -= *moved;
+      if (err == SP_ERR_IO_EOF && r->remaining) {
+        r->err = SP_HTTP_ERR_PROTOCOL;
+        return SP_ERR_IO;
+      }
+      return err;
+    }
+    case SP_HTTP_BODY_CHUNKED: {
+      if (!r->remaining) {
+        sp_http_error_t herr = sp_http_chunk_begin(r);
+        if (herr != SP_HTTP_OK) {
+          r->err = herr;
+          return SP_ERR_IO;
+        }
+        if (r->done) return SP_ERR_IO_EOF;
+      }
+      u64 n = sp_min(size, r->remaining);
+      sp_err_t err = dst
+        ? sp_io_read(r->inner, dst, n, moved)
+        : sp_io_discard(r->inner, n, moved);
+      r->remaining -= *moved;
+      if (!r->remaining) r->line_pending = true;
+      if (err == SP_ERR_IO_EOF) {
+        r->err = SP_HTTP_ERR_PROTOCOL;
+        return SP_ERR_IO;
+      }
+      return err;
+    }
   }
-  if (!body) {
-    sp_err_t err = sp_io_discard(reader, SP_LIMIT_U64_MAX, SP_NULLPTR);
-    if (err != SP_OK && err != SP_ERR_IO_EOF) return sp_http_map_io(err, SP_HTTP_ERR_PROTOCOL);
-    return SP_HTTP_OK;
-  }
-  u64 copied = 0;
-  sp_err_t err = sp_io_copy(body, reader, &copied);
-  if (written) *written += copied;
+  return SP_ERR_IO;
+}
+
+SP_PRIVATE sp_err_t sp_http_body_reader_read(sp_io_reader_t* reader, void* ptr, u64 size, u64* bytes_read) {
+  sp_http_body_reader_t* r = (sp_http_body_reader_t*)reader;
+  u64 moved = 0;
+  sp_err_t err = sp_http_body_reader_advance(r, ptr, size, &moved);
+  if (bytes_read) *bytes_read = moved;
+  return err;
+}
+
+SP_PRIVATE sp_err_t sp_http_body_reader_discard(sp_io_reader_t* reader, u64 n, u64* discarded) {
+  sp_http_body_reader_t* r = (sp_http_body_reader_t*)reader;
+  return sp_http_body_reader_advance(r, SP_NULLPTR, n, discarded);
+}
+
+void sp_http_body_reader_init(sp_http_body_reader_t* r, sp_io_reader_t* inner, sp_http_body_t body) {
+  *r = sp_zero_s(sp_http_body_reader_t);
+  r->base.read = sp_http_body_reader_read;
+  r->base.discard = sp_http_body_reader_discard;
+  r->inner = inner;
+  r->kind = body.kind;
+  if (body.kind == SP_HTTP_BODY_LENGTH) r->remaining = body.length;
+}
+
+sp_http_error_t sp_http_body_read(sp_io_reader_t* reader, sp_http_body_t body, sp_io_writer_t* sink, u64* len) {
+  sp_http_body_reader_t r = sp_zero;
+  sp_http_body_reader_init(&r, reader, body);
+  u64 moved = 0;
+  sp_err_t err = sink
+    ? sp_io_copy(sink, &r.base, &moved)
+    : sp_io_discard(&r.base, SP_LIMIT_U64_MAX, &moved);
+  if (len) *len = moved;
+  if (r.err != SP_HTTP_OK) return r.err;
+  if (!sink && err == SP_ERR_IO_EOF) err = SP_OK;
   if (err != SP_OK) return sp_http_map_io(err, SP_HTTP_ERR_PROTOCOL);
   return SP_HTTP_OK;
 }
 
-SP_PRIVATE sp_str_t sp_http_method_name(sp_http_method_t method) {
-  switch (method) {
-    case SP_HTTP_GET:    return sp_str_lit("GET");
-    case SP_HTTP_POST:   return sp_str_lit("POST");
-    case SP_HTTP_PUT:    return sp_str_lit("PUT");
-    case SP_HTTP_PATCH:  return sp_str_lit("PATCH");
-    case SP_HTTP_DELETE: return sp_str_lit("DELETE");
-  }
-  return sp_str_lit("GET");
-}
-
-SP_PRIVATE bool sp_http_headers_have(const sp_http_header_t* headers, sp_str_t name) {
-  sp_for(it, SP_HTTP_MAX_HEADERS) {
-    if (sp_str_empty(headers[it].name)) break;
+SP_PRIVATE bool sp_http_header_list_have(const sp_http_header_t* headers, u32 count, sp_str_t name) {
+  sp_for(it, count) {
     if (sp_http_ci_equal(headers[it].name, name)) return true;
   }
   return false;
 }
 
-SP_PRIVATE sp_http_error_t sp_http_headers_check(const sp_http_header_t* headers) {
-  sp_for(it, SP_HTTP_MAX_HEADERS) {
-    sp_str_t name = headers[it].name;
-    sp_str_t value = headers[it].value;
-    if (sp_str_empty(name)) break;
-    sp_for(at, name.len) {
-      u8 c = (u8)name.data[at];
-      if (c <= 0x20 || c >= 0x7f || c == ':') return SP_HTTP_ERR_BAD_CONFIG;
-    }
-    sp_for(at, value.len) {
-      u8 c = (u8)value.data[at];
-      if ((c < 0x20 && c != '\t') || c == 0x7f) return SP_HTTP_ERR_BAD_CONFIG;
-    }
-    if (sp_http_ci_equal(name, sp_str_lit("content-length")) ||
-        sp_http_ci_equal(name, sp_str_lit("transfer-encoding")) ||
-        sp_http_ci_equal(name, sp_str_lit("connection"))) {
-      return SP_HTTP_ERR_BAD_CONFIG;
-    }
+SP_PRIVATE bool sp_http_headers_reserved(const sp_http_header_t* headers, u32 count) {
+  return sp_http_header_list_have(headers, count, sp_str_lit("content-length")) ||
+         sp_http_header_list_have(headers, count, sp_str_lit("transfer-encoding")) ||
+         sp_http_header_list_have(headers, count, sp_str_lit("connection"));
+}
+
+SP_PRIVATE sp_http_error_t sp_http_header_write(sp_io_writer_t* writer, sp_http_header_t header) {
+  sp_err_t err = sp_fmt_io(writer, "{}: {}\r\n", sp_fmt_str(header.name), sp_fmt_str(header.value));
+  return err == SP_OK ? SP_HTTP_OK : sp_http_map_io(err, SP_HTTP_ERR_OS);
+}
+
+SP_PRIVATE sp_http_error_t sp_http_headers_write(sp_io_writer_t* writer, const sp_http_header_t* headers, u32 count) {
+  sp_http_error_t err = sp_http_headers_check(headers, count);
+  if (err != SP_HTTP_OK) return err;
+  sp_for(it, count) {
+    err = sp_http_header_write(writer, headers[it]);
+    if (err != SP_HTTP_OK) return err;
   }
   return SP_HTTP_OK;
+}
+
+sp_http_error_t sp_http_request_head_write(sp_io_writer_t* writer, sp_str_t method, sp_str_t target, const sp_http_header_t* headers, u32 count) {
+  if (!sp_http_token_ok(method)) return SP_HTTP_ERR_BAD_CONFIG;
+  if (sp_str_empty(target) || !sp_http_url_path_ok(target)) return SP_HTTP_ERR_BAD_CONFIG;
+  sp_err_t err = sp_fmt_io(writer, "{} {} HTTP/1.1\r\n", sp_fmt_str(method), sp_fmt_str(target));
+  if (err != SP_OK) return sp_http_map_io(err, SP_HTTP_ERR_OS);
+  sp_http_error_t herr = sp_http_headers_write(writer, headers, count);
+  if (herr != SP_HTTP_OK) return herr;
+  err = sp_io_write_str(writer, sp_str_lit("\r\n"), SP_NULLPTR);
+  return err == SP_OK ? SP_HTTP_OK : sp_http_map_io(err, SP_HTTP_ERR_OS);
+}
+
+SP_PRIVATE sp_http_error_t sp_http_response_head_io(sp_io_writer_t* writer, s32 status, const sp_http_header_t* headers, u32 count) {
+  if (status < 100 || status > 599) return SP_HTTP_ERR_BAD_CONFIG;
+  sp_err_t err = sp_fmt_io(writer, "HTTP/1.1 {} {}\r\n", sp_fmt_int(status), sp_fmt_str(sp_http_status_reason(status)));
+  if (err != SP_OK) return sp_http_map_io(err, SP_HTTP_ERR_OS);
+  return sp_http_headers_write(writer, headers, count);
+}
+
+sp_http_error_t sp_http_response_head_write(sp_io_writer_t* writer, s32 status, const sp_http_header_t* headers, u32 count) {
+  sp_http_error_t err = sp_http_response_head_io(writer, status, headers, count);
+  if (err != SP_HTTP_OK) return err;
+  sp_err_t werr = sp_io_write_str(writer, sp_str_lit("\r\n"), SP_NULLPTR);
+  return werr == SP_OK ? SP_HTTP_OK : sp_http_map_io(werr, SP_HTTP_ERR_OS);
+}
+
+sp_http_error_t sp_http_response_write(sp_io_writer_t* writer, s32 status, const sp_http_header_t* headers, u32 count, sp_str_t body) {
+  if (sp_http_header_list_have(headers, count, sp_str_lit("content-length")) ||
+      sp_http_header_list_have(headers, count, sp_str_lit("transfer-encoding"))) {
+    return SP_HTTP_ERR_BAD_CONFIG;
+  }
+  sp_http_error_t err = sp_http_response_head_io(writer, status, headers, count);
+  if (err != SP_HTTP_OK) return err;
+  sp_err_t werr = sp_fmt_io(writer, "Content-Length: {}\r\n\r\n", sp_fmt_uint(body.len));
+  if (werr != SP_OK) return sp_http_map_io(werr, SP_HTTP_ERR_OS);
+  werr = sp_io_write_str(writer, body, SP_NULLPTR);
+  return werr == SP_OK ? SP_HTTP_OK : sp_http_map_io(werr, SP_HTTP_ERR_OS);
 }
 
 SP_PRIVATE sp_str_t sp_http_build_request(sp_mem_t mem, sp_http_wire_t wire) {
@@ -825,20 +1102,22 @@ SP_PRIVATE sp_str_t sp_http_build_request(sp_mem_t mem, sp_http_wire_t wire) {
   if (!sp_str_empty(path) && path.data[0] == '?') {
     path = sp_fmt(mem, "/{}", sp_fmt_str(path)).value;
   }
-  sp_str_t target = wire.absolute_form
-    ? sp_fmt(mem, "http://{}{}", sp_fmt_str(host_header), sp_fmt_str(path)).value
-    : path;
 
   sp_io_dyn_mem_writer_t head = sp_zero;
   sp_io_dyn_mem_writer_init(mem, &head);
-  sp_io_write_str(&head.base, sp_fmt(mem, "{} {} HTTP/1.1\r\n", sp_fmt_str(sp_http_method_name(wire.method)), sp_fmt_str(target)).value, SP_NULLPTR);
-  if (!sp_http_headers_have(wire.headers, sp_str_lit("host"))) {
-    sp_io_write_str(&head.base, sp_fmt(mem, "Host: {}\r\n", sp_fmt_str(host_header)).value, SP_NULLPTR);
+  if (wire.absolute_form) {
+    sp_fmt_io(&head.base, "{} http://{}{} HTTP/1.1\r\n", sp_fmt_str(sp_http_method_name(wire.method)), sp_fmt_str(host_header), sp_fmt_str(path));
   }
-  if (!sp_http_headers_have(wire.headers, sp_str_lit("user-agent"))) {
+  else {
+    sp_fmt_io(&head.base, "{} {} HTTP/1.1\r\n", sp_fmt_str(sp_http_method_name(wire.method)), sp_fmt_str(path));
+  }
+  if (!sp_http_header_list_have(wire.headers, wire.num_headers, sp_str_lit("host"))) {
+    sp_fmt_io(&head.base, "Host: {}\r\n", sp_fmt_str(host_header));
+  }
+  if (!sp_http_header_list_have(wire.headers, wire.num_headers, sp_str_lit("user-agent"))) {
     sp_io_write_str(&head.base, sp_str_lit("User-Agent: sp-http/1.0\r\n"), SP_NULLPTR);
   }
-  if (!sp_http_headers_have(wire.headers, sp_str_lit("accept"))) {
+  if (!sp_http_header_list_have(wire.headers, wire.num_headers, sp_str_lit("accept"))) {
     sp_io_write_str(&head.base, sp_str_lit("Accept: */*\r\n"), SP_NULLPTR);
   }
   sp_io_write_str(&head.base, sp_str_lit("Connection: close\r\n"), SP_NULLPTR);
@@ -847,19 +1126,19 @@ SP_PRIVATE sp_str_t sp_http_build_request(sp_mem_t mem, sp_http_wire_t wire) {
     wire.method == SP_HTTP_PUT ||
     wire.method == SP_HTTP_PATCH;
   if (body_expected || !sp_str_empty(wire.payload)) {
-    sp_io_write_str(&head.base, sp_fmt(mem, "Content-Length: {}\r\n", sp_fmt_uint(wire.payload.len)).value, SP_NULLPTR);
+    sp_fmt_io(&head.base, "Content-Length: {}\r\n", sp_fmt_uint(wire.payload.len));
   }
-  if (!sp_str_empty(wire.payload) && !sp_str_empty(wire.content_type) && !sp_http_headers_have(wire.headers, sp_str_lit("content-type"))) {
-    sp_io_write_str(&head.base, sp_fmt(mem, "Content-Type: {}\r\n", sp_fmt_str(wire.content_type)).value, SP_NULLPTR);
+  if (!sp_str_empty(wire.payload) && !sp_str_empty(wire.content_type) && !sp_http_header_list_have(wire.headers, wire.num_headers, sp_str_lit("content-type"))) {
+    sp_fmt_io(&head.base, "Content-Type: {}\r\n", sp_fmt_str(wire.content_type));
   }
-  sp_for(it, SP_HTTP_MAX_HEADERS) {
-    if (sp_str_empty(wire.headers[it].name)) break;
+  sp_for(it, wire.num_headers) {
+    sp_http_header_t header = wire.headers[it];
     if (wire.strip_auth &&
-        (sp_http_ci_equal(wire.headers[it].name, sp_str_lit("authorization")) ||
-         sp_http_ci_equal(wire.headers[it].name, sp_str_lit("cookie")))) {
+        (sp_http_ci_equal(header.name, sp_str_lit("authorization")) ||
+         sp_http_ci_equal(header.name, sp_str_lit("cookie")))) {
       continue;
     }
-    sp_io_write_str(&head.base, sp_fmt(mem, "{}: {}\r\n", sp_fmt_str(wire.headers[it].name), sp_fmt_str(wire.headers[it].value)).value, SP_NULLPTR);
+    sp_http_header_write(&head.base, header);
   }
   sp_io_write_str(&head.base, sp_str_lit("\r\n"), SP_NULLPTR);
   return sp_io_dyn_mem_writer_as_str(&head);
@@ -991,8 +1270,6 @@ SP_PRIVATE sp_http_error_t sp_http_connect_addr(sp_sys_socket_t* out, sp_http_ad
   }
 
   if (connected) {
-    // Stays nonblocking: sp_io socket timeouts and the WANT_READ/WANT_WRITE
-    // pumps depend on it.
     *out = (sp_sys_socket_t)fd;
     return SP_HTTP_OK;
   }
@@ -1035,9 +1312,6 @@ SP_PRIVATE sp_http_error_t sp_http_conn_write(sp_http_conn_t* conn, sp_str_t dat
   return err == SP_OK ? SP_HTTP_OK : sp_http_map_io(err, SP_HTTP_ERR_OS);
 }
 
-// reads the proxy's reply to CONNECT one byte at a time; the reader is
-// unbuffered here, so nothing past the head is consumed and the TLS handshake
-// sees a clean stream
 SP_PRIVATE sp_http_error_t sp_http_connect_reply(sp_http_conn_t* conn) {
   sp_mem_arena_marker_t scratch = sp_mem_begin_scratch();
   c8* head = sp_alloc_n(scratch.mem, c8, SP_HTTP_HEAD_MAX);
@@ -1054,8 +1328,8 @@ SP_PRIVATE sp_http_error_t sp_http_connect_reply(sp_http_conn_t* conn) {
     len += n;
 
     if (sp_str_ends_with(sp_str(head, (u32)len), sp_str_lit("\r\n\r\n"))) {
-      sp_http_head_t parsed = sp_zero;
-      if (sp_http_parse_head(sp_str(head, (u32)len - 4), &parsed) == SP_HTTP_OK &&
+      sp_http_response_head_t parsed = sp_zero;
+      if (sp_http_response_head_parse(sp_str(head, (u32)len - 4), &parsed) == SP_HTTP_OK &&
           parsed.status >= 200 && parsed.status <= 299) {
         result = SP_HTTP_OK;
       }
@@ -1121,7 +1395,8 @@ sp_http_error_t sp_http_fetch(sp_mem_t mem, sp_http_request_t request, sp_http_r
   u32 io_timeout = sp_http_timeout_ms(request.io_timeout_ms, SP_HTTP_DEFAULT_IO_TIMEOUT_MS);
   sp_http_resolver_t resolver = request.resolver.resolve ? request.resolver : sp_http_resolver_default();
   sp_str_t current = request.url;
-  sp_http_error_t result = sp_http_headers_check(request.headers);
+  sp_http_error_t result = sp_http_headers_check(request.headers, request.num_headers);
+  if (result == SP_HTTP_OK && sp_http_headers_reserved(request.headers, request.num_headers)) result = SP_HTTP_ERR_BAD_CONFIG;
   u32 redirects = 0;
 
   if (result != SP_HTTP_OK) {
@@ -1177,6 +1452,7 @@ sp_http_error_t sp_http_fetch(sp_mem_t mem, sp_http_request_t request, sp_http_r
       .payload       = payload,
       .content_type  = content_type,
       .headers       = request.headers,
+      .num_headers   = request.num_headers,
       .strip_auth    = !sp_http_ci_equal(url.host, origin_host) || (origin_tls && !url.tls),
     }));
     sp_mem_end_scratch(scratch);
@@ -1190,14 +1466,14 @@ sp_http_error_t sp_http_fetch(sp_mem_t mem, sp_http_request_t request, sp_http_r
 
     sp_io_reader_set_buffer(conn.reader, conn.buffer, sizeof(conn.buffer));
 
-    sp_http_head_t parsed = sp_zero;
+    sp_http_response_head_t parsed = sp_zero;
     u32 interim = 0;
     for (;;) {
       sp_str_t head = sp_zero;
-      result = sp_http_read_head(conn.reader, &head);
+      result = sp_http_head_read(conn.reader, &head);
       if (result != SP_HTTP_OK) break;
 
-      result = sp_http_parse_head(head, &parsed);
+      result = sp_http_response_head_parse(head, &parsed);
       if (result != SP_HTTP_OK) break;
 
       if (parsed.status >= 100 && parsed.status <= 199) {
@@ -1217,39 +1493,45 @@ sp_http_error_t sp_http_fetch(sp_mem_t mem, sp_http_request_t request, sp_http_r
     resp.status = parsed.status;
     resp.url = current;
 
+    sp_str_t location = sp_http_headers_find(parsed.headers, sp_str_lit("location"));
     bool is_redirect =
       parsed.status == 301 || parsed.status == 302 || parsed.status == 303 ||
       parsed.status == 307 || parsed.status == 308;
-    if (is_redirect && !sp_str_empty(parsed.location)) {
+    if (is_redirect && !sp_str_empty(location)) {
       if (redirects++ >= max) {
         result = SP_HTTP_ERR_REDIRECTS;
         sp_http_conn_close(&conn);
         break;
       }
-      bool rewrite = parsed.status == 303 ||
-        ((parsed.status == 301 || parsed.status == 302) && method != SP_HTTP_GET);
+      bool rewrite =
+        (parsed.status == 301 || parsed.status == 302 || parsed.status == 303) &&
+        method != SP_HTTP_GET && method != SP_HTTP_HEAD;
       if (rewrite) {
         method = SP_HTTP_GET;
         payload = sp_zero_s(sp_str_t);
         content_type = sp_zero_s(sp_str_t);
       }
-      current = sp_http_resolve_url(mem, url, parsed.location);
+      current = sp_http_resolve_url(mem, url, location);
       sp_http_conn_close(&conn);
       continue;
     }
 
-    resp.content_type = sp_str_copy(mem, parsed.content_type);
-    resp.location = sp_str_copy(mem, parsed.location);
+    sp_http_body_t body = sp_zero;
+    result = sp_http_response_body_parse(parsed.status, method == SP_HTTP_HEAD, parsed.headers, &body);
+    if (result != SP_HTTP_OK) {
+      sp_http_conn_close(&conn);
+      break;
+    }
 
-    u64 written = 0;
-    result = sp_http_read_body(conn.reader, parsed, request.sink, request.sink ? &written : SP_NULLPTR);
-    resp.body_len = written;
+    resp.headers = sp_str_copy(mem, parsed.headers);
+
+    u64 len = 0;
+    result = sp_http_body_read(conn.reader, body, request.sink, &len);
+    resp.body_len = len;
     sp_http_conn_close(&conn);
 
     if (result != SP_HTTP_OK) break;
-    if (parsed.status >= 400)                          result = SP_HTTP_ERR_STATUS;
-    else if (parsed.status >= 200 && parsed.status < 300) result = SP_HTTP_OK;
-    else                                               result = SP_HTTP_ERR_PROTOCOL;
+    result = parsed.status >= 200 && parsed.status < 300 ? SP_HTTP_OK : SP_HTTP_ERR_STATUS;
     break;
   }
 
@@ -1288,6 +1570,21 @@ sp_http_error_t sp_http_fetch(sp_mem_t mem, sp_http_request_t request, sp_http_r
 #include <CoreFoundation/CoreFoundation.h>
 #endif
 
+SP_PRIVATE sp_tls_backend_t sp_tls_native_backend(void) {
+#if defined(SP_WIN32)
+  return SP_TLS_BACKEND_OS_VERIFY;
+#elif defined(SP_MACOS) && defined(SP_TLS_MACOS_SECTRUST)
+  return SP_TLS_BACKEND_OS_VERIFY;
+#elif defined(SP_MACOS)
+  // If you didn't compile in SecTrust, fail here instead of at runtime
+  return SP_TLS_BACKEND_NONE;
+#elif defined(SP_LINUX)
+  return SP_TLS_BACKEND_ANCHORS;
+#else
+  return SP_TLS_BACKEND_NONE;
+#endif
+}
+
 SP_PRIVATE u32 sp_tls_chain_count(const mbedtls_x509_crt* chain) {
   u32 count = 0;
   const mbedtls_x509_crt* it = chain;
@@ -1316,14 +1613,9 @@ void sp_tls_trust_free(sp_tls_trust_t* trust) {
 }
 
 sp_http_error_t sp_tls_trust_load(sp_tls_trust_t* trust) {
-  trust->backend = sp_tls_native_backend();
   switch (trust->backend) {
     case SP_TLS_BACKEND_ANCHORS:
-#if defined(SP_WIN32)
-      return sp_tls_load_windows(trust->anchors, trust->mem, &trust->loaded, &trust->skipped);
-#else
-      return sp_tls_load_unix(trust->anchors, trust->mem, &trust->loaded, &trust->skipped);
-#endif
+      return sp_tls_load_unix(trust->anchors, &trust->loaded, &trust->skipped);
     case SP_TLS_BACKEND_OS_VERIFY:
       return SP_HTTP_OK;
     case SP_TLS_BACKEND_NONE:
@@ -1332,18 +1624,18 @@ sp_http_error_t sp_tls_trust_load(sp_tls_trust_t* trust) {
   return SP_HTTP_ERR_UNSUPPORTED;
 }
 
-sp_http_error_t sp_tls_load_pem(struct mbedtls_x509_crt* chain, sp_str_t path, u32* loaded, u32* skipped) {
+sp_http_error_t sp_tls_load_pem(mbedtls_x509_crt* chain, sp_str_t path, u32* loaded, u32* skipped) {
   sp_mem_arena_marker_t scratch = sp_mem_begin_scratch();
   sp_str_t content = sp_zero;
   sp_http_error_t result = SP_HTTP_ERR_NO_STORE;
   if (sp_io_read_file(scratch.mem, path, &content) == SP_OK) {
     c8* pem = sp_str_to_cstr(scratch.mem, content);
-    s32 rc = mbedtls_x509_crt_parse((mbedtls_x509_crt*)chain, (const unsigned char*)pem, (size_t)content.len + 1);
+    s32 rc = mbedtls_x509_crt_parse(chain, (const unsigned char*)pem, (size_t)content.len + 1);
     if (rc < 0) {
       result = SP_HTTP_ERR_PARSE;
     }
     else {
-      if (loaded)  *loaded = sp_tls_chain_count((mbedtls_x509_crt*)chain);
+      if (loaded)  *loaded = sp_tls_chain_count(chain);
       if (skipped) *skipped = (u32)rc;
       result = SP_HTTP_OK;
     }
@@ -1352,8 +1644,7 @@ sp_http_error_t sp_tls_load_pem(struct mbedtls_x509_crt* chain, sp_str_t path, u
   return result;
 }
 
-sp_http_error_t sp_tls_load_unix(struct mbedtls_x509_crt* chain, sp_mem_t mem, u32* loaded, u32* skipped) {
-  (void)mem;
+SP_PRIVATE sp_http_error_t sp_tls_load_unix(mbedtls_x509_crt* chain, u32* loaded, u32* skipped) {
   sp_str_t env = sp_os_env_get(sp_str_lit("SSL_CERT_FILE"));
   if (!sp_str_empty(env)) {
     return sp_tls_load_pem(chain, env, loaded, skipped);
@@ -1374,69 +1665,12 @@ sp_http_error_t sp_tls_load_unix(struct mbedtls_x509_crt* chain, sp_mem_t mem, u
   return SP_HTTP_ERR_NO_STORE;
 }
 
-#if defined(SP_WIN32)
-SP_PRIVATE bool sp_tls_win32_server_auth(PCCERT_CONTEXT ctx) {
-  DWORD size = 0;
-  if (!CertGetEnhancedKeyUsage(ctx, 0, SP_NULLPTR, &size)) return false;
-  bool result = false;
-  sp_mem_arena_marker_t scratch = sp_mem_begin_scratch();
-  PCERT_ENHKEY_USAGE usage = (PCERT_ENHKEY_USAGE)sp_alloc(scratch.mem, size);
-  if (CertGetEnhancedKeyUsage(ctx, 0, usage, &size)) {
-    if (usage->cUsageIdentifier == 0) {
-      result = GetLastError() == CRYPT_E_NOT_FOUND;
-    }
-    else {
-      sp_for(it, usage->cUsageIdentifier) {
-        if (sp_cstr_equal(usage->rgpszUsageIdentifier[it], "1.3.6.1.5.5.7.3.1")) {
-          result = true;
-          break;
-        }
-      }
-    }
-  }
-  sp_mem_end_scratch(scratch);
-  return result;
-}
-
-sp_http_error_t sp_tls_load_windows(struct mbedtls_x509_crt* chain, sp_mem_t mem, u32* loaded, u32* skipped) {
-  (void)mem;
-  mbedtls_x509_crt* certs = (mbedtls_x509_crt*)chain;
-  u32 skip = 0;
-  HCERTSTORE store = CertOpenSystemStoreA(0, "ROOT");
-  if (!store) return SP_HTTP_ERR_NO_STORE;
-  PCCERT_CONTEXT ctx = SP_NULLPTR;
-  while ((ctx = CertEnumCertificatesInStore(store, ctx)) != SP_NULLPTR) {
-    if (!(ctx->dwCertEncodingType & X509_ASN_ENCODING)) continue;
-    if (!sp_tls_win32_server_auth(ctx)) {
-      skip++;
-      continue;
-    }
-    if (mbedtls_x509_crt_parse_der(certs, ctx->pbCertEncoded, ctx->cbCertEncoded) != 0) skip++;
-  }
-  CertCloseStore(store, 0);
-  if (loaded)  *loaded = sp_tls_chain_count(certs);
-  if (skipped) *skipped = skip;
-  return sp_tls_chain_count(certs) ? SP_HTTP_OK : SP_HTTP_ERR_NO_STORE;
-}
-#else
-sp_http_error_t sp_tls_load_windows(struct mbedtls_x509_crt* chain, sp_mem_t mem, u32* loaded, u32* skipped) {
-  (void)chain; (void)mem;
-  if (loaded)  *loaded = 0;
-  if (skipped) *skipped = 0;
-  return SP_HTTP_ERR_UNSUPPORTED;
-}
-#endif
-
-sp_http_error_t sp_tls_conf_apply(const sp_tls_trust_t* trust, struct mbedtls_ssl_config* conf) {
-  mbedtls_ssl_config* cfg = (mbedtls_ssl_config*)conf;
+SP_PRIVATE sp_http_error_t sp_tls_conf_apply(const sp_tls_trust_t* trust, mbedtls_ssl_config* conf) {
   switch (trust->backend) {
     case SP_TLS_BACKEND_ANCHORS:
-      mbedtls_ssl_conf_authmode(cfg, MBEDTLS_SSL_VERIFY_REQUIRED);
-      mbedtls_ssl_conf_ca_chain(cfg, (mbedtls_x509_crt*)trust->anchors, SP_NULLPTR);
-      return SP_HTTP_OK;
     case SP_TLS_BACKEND_OS_VERIFY:
-      mbedtls_ssl_conf_authmode(cfg, MBEDTLS_SSL_VERIFY_REQUIRED);
-      mbedtls_ssl_conf_ca_chain(cfg, (mbedtls_x509_crt*)trust->anchors, SP_NULLPTR);
+      mbedtls_ssl_conf_authmode(conf, MBEDTLS_SSL_VERIFY_REQUIRED);
+      mbedtls_ssl_conf_ca_chain(conf, trust->anchors, SP_NULLPTR);
       return SP_HTTP_OK;
     case SP_TLS_BACKEND_NONE:
       return SP_HTTP_ERR_UNSUPPORTED;
@@ -1444,24 +1678,23 @@ sp_http_error_t sp_tls_conf_apply(const sp_tls_trust_t* trust, struct mbedtls_ss
   return SP_HTTP_ERR_UNSUPPORTED;
 }
 
-sp_http_error_t sp_tls_ssl_attach(const sp_tls_trust_t* trust, struct mbedtls_ssl_context* ssl, sp_tls_verify_t* verify, sp_str_t hostname) {
-  mbedtls_ssl_context* context = (mbedtls_ssl_context*)ssl;
+SP_PRIVATE sp_http_error_t sp_tls_ssl_attach(const sp_tls_trust_t* trust, mbedtls_ssl_context* ssl, sp_tls_verify_t* verify, sp_str_t hostname) {
   if (sp_str_empty(hostname) || hostname.len >= SP_PATH_MAX) return SP_HTTP_ERR_URL;
   c8 host[SP_PATH_MAX];
   sp_cstr_copy_to_n(hostname.data, hostname.len, host, sizeof(host));
-  if (mbedtls_ssl_set_hostname(context, host) != 0) return SP_HTTP_ERR_OS;
+  if (mbedtls_ssl_set_hostname(ssl, host) != 0) return SP_HTTP_ERR_OS;
   if (trust->backend == SP_TLS_BACKEND_OS_VERIFY) {
 #if !defined(MBEDTLS_SSL_KEEP_PEER_CERTIFICATE)
     return SP_HTTP_ERR_BAD_CONFIG;
 #else
     if (verify) verify->hostname = hostname;
-    mbedtls_ssl_set_verify(context, sp_tls_verify_cb, verify);
+    mbedtls_ssl_set_verify(ssl, sp_tls_verify_cb, verify);
 #endif
   }
   return SP_HTTP_OK;
 }
 
-s32 sp_tls_verify_cb(void* user_data, struct mbedtls_x509_crt* crt, s32 depth, u32* flags) {
+SP_PRIVATE s32 sp_tls_verify_cb(void* user_data, mbedtls_x509_crt* crt, s32 depth, u32* flags) {
   *flags = 0;
   if (depth != 0) return 0;
   sp_tls_verify_t* verify = (sp_tls_verify_t*)user_data;
@@ -1477,7 +1710,7 @@ s32 sp_tls_verify_cb(void* user_data, struct mbedtls_x509_crt* crt, s32 depth, u
   return 0;
 }
 
-sp_http_error_t sp_tls_macos_eval(const struct mbedtls_x509_crt* chain, sp_str_t hostname) {
+SP_PRIVATE sp_http_error_t sp_tls_macos_eval(const mbedtls_x509_crt* chain, sp_str_t hostname) {
 #if defined(SP_MACOS) && defined(SP_TLS_MACOS_SECTRUST)
   if (sp_str_empty(hostname) || hostname.len >= SP_PATH_MAX) return SP_HTTP_ERR_UNTRUSTED;
 
@@ -1485,7 +1718,7 @@ sp_http_error_t sp_tls_macos_eval(const struct mbedtls_x509_crt* chain, sp_str_t
   if (!certs) return SP_HTTP_ERR_OS;
 
   bool converted = true;
-  const mbedtls_x509_crt* it = (const mbedtls_x509_crt*)chain;
+  const mbedtls_x509_crt* it = chain;
   while (it) {
     CFDataRef der = CFDataCreate(SP_NULLPTR, it->raw.p, (CFIndex)it->raw.len);
     SecCertificateRef cert = der ? SecCertificateCreateWithData(SP_NULLPTR, der) : SP_NULLPTR;
@@ -1525,9 +1758,9 @@ sp_http_error_t sp_tls_macos_eval(const struct mbedtls_x509_crt* chain, sp_str_t
 #endif
 }
 
-sp_http_error_t sp_tls_windows_eval(const struct mbedtls_x509_crt* chain, sp_str_t hostname) {
+SP_PRIVATE sp_http_error_t sp_tls_windows_eval(const mbedtls_x509_crt* chain, sp_str_t hostname) {
 #if defined(SP_WIN32)
-  const mbedtls_x509_crt* leaf = (const mbedtls_x509_crt*)chain;
+  const mbedtls_x509_crt* leaf = chain;
   if (!leaf) return SP_HTTP_ERR_UNTRUSTED;
   if (sp_str_empty(hostname) || hostname.len >= SP_PATH_MAX) return SP_HTTP_ERR_UNTRUSTED;
 
@@ -1583,24 +1816,6 @@ sp_http_error_t sp_tls_windows_eval(const struct mbedtls_x509_crt* chain, sp_str
 #endif
 }
 
-sp_http_error_t sp_tls_chain_der(const struct mbedtls_x509_crt* chain, sp_mem_t mem, sp_mem_slice_t** ders, u32* count) {
-  u32 total = sp_tls_chain_count((const mbedtls_x509_crt*)chain);
-  sp_mem_slice_t* out = sp_alloc_n(mem, sp_mem_slice_t, total);
-  const mbedtls_x509_crt* it = (const mbedtls_x509_crt*)chain;
-  u32 index = 0;
-  while (it) {
-    out[index].data = it->raw.p;
-    out[index].len = it->raw.len;
-    it = it->next;
-    index++;
-  }
-  if (ders)  *ders = out;
-  if (count) *count = total;
-  return SP_HTTP_OK;
-}
-
-// mbedtls returns WANT_READ/WANT_WRITE when the nonblocking socket has no
-// data/space; park on the socket until it's ready or the io timeout expires.
 SP_PRIVATE sp_err_t sp_tls_mbedtls_wait(sp_tls_mbedtls_t* tls, s32 rc) {
   bool readable = rc == MBEDTLS_ERR_SSL_WANT_READ;
   sp_err_t wait = sp_sys_socket_wait(tls->socket, readable, tls->io_timeout_ms);
@@ -1621,7 +1836,6 @@ SP_PRIVATE sp_err_t sp_tls_mbedtls_read(sp_io_reader_t* reader, void* ptr, u64 s
       continue;
     }
     if (n == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
-      // latched: mbedtls reports close_notify only once, then raw EOF
       wrapper->eof = true;
       return SP_ERR_IO_EOF;
     }
@@ -1721,78 +1935,6 @@ void sp_tls_mbedtls_init(sp_tls_mbedtls_t* tls, const sp_tls_trust_t* trust) {
   tls->reader.tls = tls;
   tls->writer.base.write = sp_tls_mbedtls_write;
   tls->writer.tls = tls;
-}
-
-#else
-
-sp_http_error_t sp_tls_trust_init(sp_tls_trust_t* trust, sp_mem_t mem) {
-  *trust = sp_zero_s(sp_tls_trust_t);
-  trust->mem = mem;
-  trust->backend = sp_tls_native_backend();
-  return SP_HTTP_OK;
-}
-
-void sp_tls_trust_free(sp_tls_trust_t* trust) {
-  *trust = sp_zero_s(sp_tls_trust_t);
-}
-
-sp_http_error_t sp_tls_trust_load(sp_tls_trust_t* trust) {
-  trust->backend = sp_tls_native_backend();
-  return SP_HTTP_ERR_UNSUPPORTED;
-}
-
-sp_http_error_t sp_tls_load_windows(struct mbedtls_x509_crt* chain, sp_mem_t mem, u32* loaded, u32* skipped) {
-  (void)chain; (void)mem;
-  if (loaded)  *loaded = 0;
-  if (skipped) *skipped = 0;
-  return SP_HTTP_ERR_UNSUPPORTED;
-}
-
-sp_http_error_t sp_tls_load_unix(struct mbedtls_x509_crt* chain, sp_mem_t mem, u32* loaded, u32* skipped) {
-  (void)chain; (void)mem;
-  if (loaded)  *loaded = 0;
-  if (skipped) *skipped = 0;
-  return SP_HTTP_ERR_UNSUPPORTED;
-}
-
-sp_http_error_t sp_tls_load_pem(struct mbedtls_x509_crt* chain, sp_str_t path, u32* loaded, u32* skipped) {
-  (void)chain; (void)path;
-  if (loaded)  *loaded = 0;
-  if (skipped) *skipped = 0;
-  return SP_HTTP_ERR_UNSUPPORTED;
-}
-
-sp_http_error_t sp_tls_conf_apply(const sp_tls_trust_t* trust, struct mbedtls_ssl_config* conf) {
-  (void)trust; (void)conf;
-  return SP_HTTP_ERR_UNSUPPORTED;
-}
-
-sp_http_error_t sp_tls_ssl_attach(const sp_tls_trust_t* trust, struct mbedtls_ssl_context* ssl, sp_tls_verify_t* verify, sp_str_t hostname) {
-  (void)trust; (void)ssl;
-  if (verify) verify->hostname = hostname;
-  return SP_HTTP_ERR_UNSUPPORTED;
-}
-
-s32 sp_tls_verify_cb(void* user_data, struct mbedtls_x509_crt* crt, s32 depth, u32* flags) {
-  (void)user_data; (void)crt; (void)depth; (void)flags;
-  return 0;
-}
-
-sp_http_error_t sp_tls_macos_eval(const struct mbedtls_x509_crt* chain, sp_str_t hostname) {
-  (void)chain; (void)hostname;
-  return SP_HTTP_ERR_UNSUPPORTED;
-}
-
-sp_http_error_t sp_tls_windows_eval(const struct mbedtls_x509_crt* chain, sp_str_t hostname) {
-  (void)chain; (void)hostname;
-  return SP_HTTP_ERR_UNSUPPORTED;
-}
-
-sp_http_error_t sp_tls_chain_der(const struct mbedtls_x509_crt* chain, sp_mem_t mem, sp_mem_slice_t** ders, u32* count) {
-  (void)chain; (void)mem;
-  if (ders)  *ders = SP_NULLPTR;
-  if (count) *count = 0;
-  return SP_HTTP_ERR_UNSUPPORTED;
 }
 
 #endif // SP_TLS_WITH_MBEDTLS

--- a/spn.toml
+++ b/spn.toml
@@ -66,6 +66,13 @@ name = "http"
 source = [
   "test/main.c",
   "test/http/*.c",
+]
+
+[[test]]
+name = "tls"
+source = [
+  "test/main.c",
+  "test/http/tls/*.c",
   "tools/vendor/mbedtls/library/*.c",
 ]
 include = ["tools/vendor/mbedtls/include", "tools/vendor/mbedtls/library"]

--- a/test/http/body.c
+++ b/test/http/body.c
@@ -1,0 +1,96 @@
+#include "http.h"
+
+typedef struct {
+  sp_http_error_t     err;
+  sp_http_body_kind_t kind;
+  u64                 length;
+} expect_t;
+
+typedef struct {
+  const c8* name;
+  header_t  headers [HTTP_TEST_MAX_HEADERS];
+  expect_t  expect;
+} test_t;
+
+static const test_t tests [] = {
+  {
+    .name = "no_framing_headers",
+    .expect = { .kind = SP_HTTP_BODY_NONE },
+  },
+  {
+    .name = "content_length",
+    .headers = { { "Content-Length", "12" } },
+    .expect = { .kind = SP_HTTP_BODY_LENGTH, .length = 12 },
+  },
+  {
+    .name = "content_length_zero",
+    .headers = { { "Content-Length", "0" } },
+    .expect = { .kind = SP_HTTP_BODY_LENGTH },
+  },
+  {
+    .name = "duplicate_equal_lengths",
+    .headers = { { "content-length", "12" }, { "Content-Length", "12" } },
+    .expect = { .kind = SP_HTTP_BODY_LENGTH, .length = 12 },
+  },
+  {
+    .name = "chunked",
+    .headers = { { "Transfer-Encoding", "chunked" } },
+    .expect = { .kind = SP_HTTP_BODY_CHUNKED },
+  },
+  {
+    .name = "chunked_in_list",
+    .headers = { { "Transfer-Encoding", "GZIP, Chunked" } },
+    .expect = { .kind = SP_HTTP_BODY_CHUNKED },
+  },
+  {
+    .name = "unrelated_headers_ignored",
+    .headers = { { "Content-Type", "text/plain" }, { "X", "1" } },
+    .expect = { .kind = SP_HTTP_BODY_NONE },
+  },
+  {
+    .name = "conflicting_lengths",
+    .headers = { { "Content-Length", "5" }, { "Content-Length", "9" } },
+    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
+  },
+  {
+    .name = "length_not_numeric",
+    .headers = { { "Content-Length", "abc" } },
+    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
+  },
+  {
+    .name = "length_empty",
+    .headers = { { "Content-Length", "" } },
+    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
+  },
+  {
+    .name = "length_overflows_u64",
+    .headers = { { "Content-Length", "99999999999999999999" } },
+    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
+  },
+  {
+    .name = "te_not_chunked",
+    .headers = { { "Transfer-Encoding", "gzip" } },
+    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
+  },
+  {
+    .name = "te_and_length",
+    .headers = { { "Transfer-Encoding", "chunked" }, { "Content-Length", "5" } },
+    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
+  },
+};
+
+static sp_err_t run(sp_test_t* t, test_t* c) {
+  sp_mem_t mem = sp_test_arena(t);
+  sp_str_t headers = header_lines(mem, c->headers, HTTP_TEST_MAX_HEADERS);
+
+  sp_http_body_t body = sp_zero;
+  sp_http_error_t err = sp_http_body_parse(headers, &body);
+  sp_expect_eq(t, (s32)err, (s32)c->expect.err);
+  if (err != SP_HTTP_OK || c->expect.err != SP_HTTP_OK) return SP_OK;
+
+  sp_expect_eq(t, (s32)body.kind, (s32)c->expect.kind);
+  sp_expect_eq(t, body.length, c->expect.length);
+  return SP_OK;
+}
+
+sp_test_each_fn(http, body, test_t, tests, run);

--- a/test/http/fetch.c
+++ b/test/http/fetch.c
@@ -7,7 +7,6 @@
 
 #define FETCH_MAX_STEPS    4
 #define FETCH_MAX_SCRIPTS  2
-#define FETCH_MAX_HEADERS  4
 #define FETCH_MAX_CAPTURED 2
 #define FETCH_MAX_COUNTED  4
 
@@ -25,31 +24,20 @@ typedef struct {
 } step_t;
 
 typedef struct {
-  const c8* name;
-  const c8* value;
-} header_t;
-
-typedef struct {
   const c8* text;
   u32       n;
 } counted_t;
 
 typedef struct {
   sp_http_error_t err;
-  s32            status;
-  const c8*      body;
-  const c8*      content_type;
-  const c8*      location;
+  s32             status;
+  const c8*       body;
+  header_t        headers [HTTP_TEST_MAX_HEADERS];
 } expect_t;
 
 typedef struct {
   const c8*        name;
-  bool             tls;
-  bool             untrusted;
-  bool             no_close_notify; // slam the connection shut after playing the script
   bool             proxy;           // send the request through the mock server as a proxy
-  bool             proxy_connect;   // the mock server expects a plaintext CONNECT preamble
-  const c8*        connect_reply;   // reply to CONNECT; defaults to 200
   const c8*        url;             // fetch url; defaults to the mock server
   const c8*        path;            // appended to the mock server url; defaults to /
   resolve_kind_t   resolve;
@@ -57,8 +45,7 @@ typedef struct {
   sp_http_method_t method;
   const c8*        payload;
   const c8*        content_type;
-  header_t         headers [FETCH_MAX_HEADERS];
-  u32              connect_timeout_ms;
+  header_t         headers [HTTP_TEST_MAX_HEADERS];
   u32              io_timeout_ms;
   step_t           scripts [FETCH_MAX_SCRIPTS][FETCH_MAX_STEPS];
   expect_t         expect;
@@ -83,6 +70,33 @@ static const test_t tests [] = {
     .expect = { .status = 204, .body = "" },
   },
   {
+    .name = "no_body_304_ignores_length",
+    .scripts = {{ { .send = "HTTP/1.1 304 Not Modified\r\nContent-Length: 20\r\n\r\n" } }},
+    .expect = { .err = SP_HTTP_ERR_STATUS, .status = 304, .body = "" },
+  },
+  {
+    .name = "head_no_body",
+    .method = SP_HTTP_HEAD,
+    .scripts = {{ { .send = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\n" } }},
+    .expect = { .status = 200, .body = "" },
+    .captured = { "HEAD / HTTP/1.1" },
+  },
+  {
+    .name = "head_redirect_stays_head",
+    .method = SP_HTTP_HEAD,
+    .scripts = {
+      { { .send = "HTTP/1.1 302 Found\r\nLocation: /next\r\n\r\n" } },
+      { { .send = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n" } },
+    },
+    .expect = { .status = 200, .body = "" },
+    .captured = { "HEAD /next HTTP/1.1" },
+  },
+  {
+    .name = "https_needs_tls",
+    .url = "https://127.0.0.1:1/",
+    .expect = { .err = SP_HTTP_ERR_BAD_CONFIG },
+  },
+  {
     .name = "early_hints",
     .scripts = {{ { .send = "HTTP/1.1 103 Early Hints\r\nLink: </s.css>; rel=preload\r\n\r\nHTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello" } }},
     .expect = { .status = 200, .body = "hello" },
@@ -103,24 +117,9 @@ static const test_t tests [] = {
     .expect = { .err = SP_HTTP_ERR_PROTOCOL },
   },
   {
-    .name = "conflicting_length",
-    .scripts = {{ { .send = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nContent-Length: 9999\r\n\r\nhello" } }},
-    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
-  },
-  {
-    .name = "te_gzip",
-    .scripts = {{ { .send = "HTTP/1.1 200 OK\r\nTransfer-Encoding: gzip\r\n\r\nblob" } }},
-    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
-  },
-  {
     .name = "chunked",
     .scripts = {{ { .send = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n" } }},
     .expect = { .status = 200, .body = "hello world" },
-  },
-  {
-    .name = "chunked_bad_separator",
-    .scripts = {{ { .send = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhelloXX\r\n0\r\n\r\n" } }},
-    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
   },
   {
     .name = "huge_head",
@@ -130,7 +129,12 @@ static const test_t tests [] = {
   {
     .name = "crlf_location",
     .scripts = {{ { .send = "HTTP/1.1 302 Found\r\nLocation: /a\rSet-Cookie: pwn=1\r\n\r\n" } }},
-    .expect = { .err = SP_HTTP_ERR_URL },
+    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
+  },
+  {
+    .name = "redirect_without_location",
+    .scripts = {{ { .send = "HTTP/1.1 302 Found\r\nContent-Length: 1\r\n\r\nx" } }},
+    .expect = { .err = SP_HTTP_ERR_STATUS, .status = 302, .body = "x" },
   },
   {
     .name = "redirect_userinfo",
@@ -159,9 +163,9 @@ static const test_t tests [] = {
     .expect = { .status = 200, .body = "hello" },
   },
   {
-    .name = "truncated_body",
-    .scripts = {{ { .send = "HTTP/1.1 200 OK\r\nContent-Length: 10\r\n\r\nhello" } }},
-    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
+    .name = "eof_body",
+    .scripts = {{ { .send = "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\nhello" } }},
+    .expect = { .status = 200, .body = "hello" },
   },
   {
     .name = "query_no_path",
@@ -169,32 +173,6 @@ static const test_t tests [] = {
     .scripts = {{ { .send = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok" } }},
     .expect = { .status = 200, .body = "ok" },
     .captured = { "GET /?a=b HTTP/1.1" },
-  },
-  {
-    .name = "eof_body",
-    .tls = true,
-    .scripts = {{ { .send = "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\nhello" } }},
-    .expect = { .status = 200, .body = "hello" },
-  },
-  {
-    .name = "eof_body_no_close_notify",
-    .tls = true,
-    .no_close_notify = true,
-    .scripts = {{ { .send = "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\nhello" } }},
-    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
-  },
-  {
-    .name = "tls_trusted",
-    .tls = true,
-    .scripts = {{ { .send = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello" } }},
-    .expect = { .status = 200, .body = "hello" },
-  },
-  {
-    .name = "tls_untrusted",
-    .tls = true,
-    .untrusted = true,
-    .scripts = {{ { .send = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello" } }},
-    .expect = { .err = SP_HTTP_ERR_UNTRUSTED },
   },
   {
     .name = "redirect_query_url",
@@ -221,36 +199,12 @@ static const test_t tests [] = {
     .expect = { .err = SP_HTTP_ERR_TIMEOUT },
   },
   {
-    .name = "timeout_tls",
-    .tls = true,
-    .io_timeout_ms = 120,
-    .scripts = {{ { .send = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello", .delay_ms = 1000 } }},
-    .expect = { .err = SP_HTTP_ERR_TIMEOUT },
-  },
-  {
     .name = "proxy_absolute_form",
     .proxy = true,
     .url = "http://example.test:8080/x",
     .scripts = {{ { .send = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok" } }},
     .expect = { .status = 200, .body = "ok" },
     .captured = { "GET http://example.test:8080/x HTTP/1.1", "Host: example.test:8080" },
-  },
-  {
-    .name = "proxy_connect",
-    .tls = true,
-    .proxy = true,
-    .proxy_connect = true,
-    .scripts = {{ { .send = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello" } }},
-    .expect = { .status = 200, .body = "hello" },
-    .captured = { "CONNECT 127.0.0.1:", "GET / HTTP/1.1" },
-  },
-  {
-    .name = "proxy_connect_refused",
-    .tls = true,
-    .proxy = true,
-    .proxy_connect = true,
-    .connect_reply = "HTTP/1.1 403 Forbidden\r\n\r\n",
-    .expect = { .err = SP_HTTP_ERR_PROXY },
   },
   {
     .name = "custom_resolver",
@@ -421,6 +375,7 @@ static const test_t tests [] = {
   },
   {
     .name = "redirect_cross_host_strips_auth",
+    .resolve = RESOLVE_LOCAL,
     .headers = { { "Authorization", "Bearer tok" }, { "Cookie", "a=1" }, { "X-Keep", "yes" } },
     .scripts = {
       { { .send = "HTTP/1.1 302 Found\r\nLocation: http://localhost:@PORT@/next\r\n\r\n" } },
@@ -441,66 +396,38 @@ static const test_t tests [] = {
     .counted = { { "Bearer tok", 2 } },
   },
   {
-    .name = "response_metadata",
+    .name = "response_headers_kept",
     .method = SP_HTTP_POST,
     .payload = "x",
     .scripts = {{ { .send = "HTTP/1.1 201 Created\r\nContent-Type: application/json\r\nLocation: /created/1\r\nContent-Length: 4\r\n\r\ndone" } }},
-    .expect = { .status = 201, .body = "done", .content_type = "application/json", .location = "/created/1" },
+    .expect = {
+      .status = 201,
+      .body = "done",
+      .headers = { { "content-type", "application/json" }, { "location", "/created/1" } },
+    },
   },
 };
 
-static const c8* fetch_cert =
-  "-----BEGIN CERTIFICATE-----\n"
-  "MIIBfjCCASWgAwIBAgIUDPglN4zQDNG5UTi2PtR5HoWKNbkwCgYIKoZIzj0EAwIw\n"
-  "FDESMBAGA1UEAwwJMTI3LjAuMC4xMCAXDTI2MDcwMTIyNTA1NloYDzIxMjYwNjA3\n"
-  "MjI1MDU2WjAUMRIwEAYDVQQDDAkxMjcuMC4wLjEwWTATBgcqhkjOPQIBBggqhkjO\n"
-  "PQMBBwNCAAQ2Hl0cVbbPLuko5otFB3zmPXuP0Lpx11IBhV1NM8Zw6kl46p9Qzc/r\n"
-  "ljXgguMNSYS3HV1wGDqZ+PON+S5OO/tUo1MwUTAdBgNVHQ4EFgQUZs7KCxZ9MnDz\n"
-  "rNhwgCN4rZrqHjgwHwYDVR0jBBgwFoAUZs7KCxZ9MnDzrNhwgCN4rZrqHjgwDwYD\n"
-  "VR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNHADBEAiA2wjJs70BXB/E2UgJFteWi\n"
-  "KHJg0TfhR8GmnwycFLKQxwIgfuDjz1eFI6NFseCI92HdSOohKe9uTWjgfYyOw/lH\n"
-  "7uk=\n"
-  "-----END CERTIFICATE-----\n";
-
-static const c8* fetch_key =
-  "-----BEGIN PRIVATE KEY-----\n"
-  "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgkOe51G2MRpZ8kyVN\n"
-  "tWv2/RKrkE9WfLCS4zbMvdlNAUOhRANCAAQ2Hl0cVbbPLuko5otFB3zmPXuP0Lpx\n"
-  "11IBhV1NM8Zw6kl46p9Qzc/rljXgguMNSYS3HV1wGDqZ+PON+S5OO/tU\n"
-  "-----END PRIVATE KEY-----\n";
-
 typedef struct {
-  mbedtls_net_context      listen;
-  sp_atomic_s32_t          stop;
-  bool                     tls;
-  bool                     no_close_notify;
-  bool                     proxy_connect;
-  const c8*                connect_reply;
-  const step_t             (*scripts) [FETCH_MAX_STEPS];
-  u32                      script_count;
-  c8                       captured [8192];
-  u32                      captured_len;
-  mbedtls_ssl_config       conf;
-  mbedtls_x509_crt         crt;
-  mbedtls_pk_context       pk;
-  mbedtls_entropy_context  entropy;
-  mbedtls_ctr_drbg_context drbg;
+  sp_sys_socket_t listener;
+  sp_atomic_s32_t stop;
+  const step_t    (*scripts) [FETCH_MAX_STEPS];
+  u32             script_count;
+  c8              captured [8192];
+  u32             captured_len;
 } server_t;
 
-static bool mock_send(mbedtls_ssl_context* ssl, mbedtls_net_context* net, const u8* data, u32 len) {
+static bool mock_send(sp_sys_socket_t socket, const u8* data, u32 len) {
   u32 sent = 0;
   while (sent < len) {
-    s32 n = ssl
-      ? mbedtls_ssl_write(ssl, data + sent, len - sent)
-      : mbedtls_net_send(net, data + sent, len - sent);
-    if (n == MBEDTLS_ERR_SSL_WANT_READ || n == MBEDTLS_ERR_SSL_WANT_WRITE) continue;
-    if (n <= 0) return false;
+    u64 n = 0;
+    if (sp_sys_socket_send(socket, data + sent, len - sent, &n) != SP_OK) return false;
     sent += (u32)n;
   }
   return true;
 }
 
-static bool mock_read_request(server_t* server, mbedtls_ssl_context* ssl, mbedtls_net_context* net) {
+static bool mock_read_request(server_t* server, sp_sys_socket_t socket) {
   c8 buf [8192];
   u32 len = 0;
   bool ok = false;
@@ -522,11 +449,9 @@ static bool mock_read_request(server_t* server, mbedtls_ssl_context* ssl, mbedtl
       }
     }
     if (len == sizeof(buf)) break;
-    s32 n = ssl
-      ? mbedtls_ssl_read(ssl, (u8*)buf + len, sizeof(buf) - len)
-      : mbedtls_net_recv(net, (u8*)buf + len, sizeof(buf) - len);
-    if (n == MBEDTLS_ERR_SSL_WANT_READ || n == MBEDTLS_ERR_SSL_WANT_WRITE) continue;
-    if (n <= 0) break;
+    u64 n = 0;
+    if (sp_sys_socket_recv(socket, (u8*)buf + len, sizeof(buf) - len, &n) != SP_OK) break;
+    if (n == 0) break;
     len += (u32)n;
   }
   u32 space = (u32)sizeof(server->captured) - server->captured_len;
@@ -536,7 +461,7 @@ static bool mock_read_request(server_t* server, mbedtls_ssl_context* ssl, mbedtl
   return ok;
 }
 
-static void mock_play(mbedtls_ssl_context* ssl, mbedtls_net_context* net, const step_t* steps) {
+static void mock_play(sp_sys_socket_t socket, const step_t* steps) {
   sp_for(it, FETCH_MAX_STEPS) {
     step_t step = steps[it];
     if (!step.send && !step.pad) break;
@@ -544,14 +469,14 @@ static void mock_play(mbedtls_ssl_context* ssl, mbedtls_net_context* net, const 
     sp_for(r, repeat) {
       if (step.delay_ms) sp_sleep_ms((f64)step.delay_ms);
       if (step.send) {
-        if (!mock_send(ssl, net, (const u8*)step.send, sp_cstr_len(step.send))) return;
+        if (!mock_send(socket, (const u8*)step.send, sp_cstr_len(step.send))) return;
       }
       u8 chunk [512];
       sp_mem_fill_u8(chunk, sizeof(chunk), 'a');
       u32 pad = step.pad;
       while (pad > 0) {
         u32 take = pad < sizeof(chunk) ? pad : (u32)sizeof(chunk);
-        if (!mock_send(ssl, net, chunk, take)) return;
+        if (!mock_send(socket, chunk, take)) return;
         pad -= take;
       }
     }
@@ -562,48 +487,18 @@ static s32 server_thread(void* userdata) {
   server_t* server = (server_t*)userdata;
   u32 index = 0;
   for (;;) {
-    mbedtls_net_context client;
-    mbedtls_net_init(&client);
-    if (mbedtls_net_accept(&server->listen, &client, SP_NULLPTR, 0, SP_NULLPTR) != 0) break;
+    sp_sys_socket_t client = SP_SYS_INVALID_SOCKET;
+    if (sp_sys_socket_accept(server->listener, (sp_sys_handle_desc_t) { SP_SYS_BLOCKING }, &client) != SP_OK) break;
     if (sp_atomic_s32_load(&server->stop, SP_ATOMIC_SEQ_CST)) {
-      mbedtls_net_free(&client);
+      sp_sys_socket_close(client);
       break;
     }
 
-    bool ok = true;
-    if (server->proxy_connect) {
-      ok = mock_read_request(server, SP_NULLPTR, &client);
-      if (ok) {
-        const c8* reply = server->connect_reply ? server->connect_reply : "HTTP/1.1 200 Connection established\r\n\r\n";
-        ok = mock_send(SP_NULLPTR, &client, (const u8*)reply, sp_cstr_len(reply));
-      }
-    }
-
-    mbedtls_ssl_context ssl;
-    mbedtls_ssl_init(&ssl);
-    mbedtls_ssl_context* sslp = server->tls ? &ssl : SP_NULLPTR;
-    if (ok && server->tls) {
-      ok = mbedtls_ssl_setup(&ssl, &server->conf) == 0;
-      if (ok) {
-        mbedtls_ssl_set_bio(&ssl, &client, mbedtls_net_send, mbedtls_net_recv, SP_NULLPTR);
-        s32 rc;
-        while ((rc = mbedtls_ssl_handshake(&ssl)) != 0) {
-          if (rc != MBEDTLS_ERR_SSL_WANT_READ && rc != MBEDTLS_ERR_SSL_WANT_WRITE) {
-            ok = false;
-            break;
-          }
-        }
-      }
-    }
-
-    if (ok) ok = mock_read_request(server, sslp, &client);
-    if (ok) {
+    if (mock_read_request(server, client)) {
       u32 which = index < server->script_count ? index : server->script_count - 1;
-      mock_play(sslp, &client, server->scripts[which]);
+      mock_play(client, server->scripts[which]);
     }
-    if (server->tls && ok && !server->no_close_notify) mbedtls_ssl_close_notify(&ssl);
-    mbedtls_ssl_free(&ssl);
-    mbedtls_net_free(&client);
+    sp_sys_socket_close(client);
     index++;
   }
   return 0;
@@ -649,21 +544,18 @@ static sp_err_t run(sp_test_t* t, test_t* c) {
 #endif
 
   server_t server = sp_zero;
-  mbedtls_net_init(&server.listen);
-  server.tls = c->tls;
-  server.no_close_notify = c->no_close_notify;
-  server.proxy_connect = c->proxy_connect;
-  server.connect_reply = c->connect_reply;
+  server.listener = SP_SYS_INVALID_SOCKET;
   server.scripts = c->scripts;
-  server.script_count = 0;
   sp_carr_for(c->scripts, it) {
     if (c->scripts[it][0].send || c->scripts[it][0].pad) server.script_count++;
   }
   if (!server.script_count) server.script_count = 1;
 
-  sp_must_eq(t, mbedtls_net_bind(&server.listen, "127.0.0.1", "0", MBEDTLS_NET_PROTO_TCP), 0);
+  sp_must_ok(t, sp_sys_socket_open(&server.listener, (sp_sys_handle_desc_t) { SP_SYS_BLOCKING }));
+  sp_must_ok(t, sp_sys_socket_bind(server.listener, (sp_sys_ipv4_t) { .octets = { 127, 0, 0, 1 } }));
+  sp_must_ok(t, sp_sys_socket_listen(server.listener, 4));
   u16 port_value = 0;
-  sp_must_ok(t, sp_sys_socket_local_port((sp_sys_socket_t)server.listen.fd, &port_value));
+  sp_must_ok(t, sp_sys_socket_local_port(server.listener, &port_value));
   const c8* port = sp_str_to_cstr(mem, sp_fmt(mem, "{}", sp_fmt_uint(port_value)).value);
 
   sp_carr_for(c->scripts, s) {
@@ -674,31 +566,8 @@ static sp_err_t run(sp_test_t* t, test_t* c) {
     }
   }
 
-  if (c->tls) {
-    mbedtls_x509_crt_init(&server.crt);
-    mbedtls_pk_init(&server.pk);
-    mbedtls_entropy_init(&server.entropy);
-    mbedtls_ctr_drbg_init(&server.drbg);
-    mbedtls_ssl_config_init(&server.conf);
-    sp_must_eq(t, mbedtls_x509_crt_parse(&server.crt, (const unsigned char*)fetch_cert, sp_cstr_len(fetch_cert) + 1), 0);
-    sp_must_eq(t, mbedtls_ctr_drbg_seed(&server.drbg, mbedtls_entropy_func, &server.entropy, SP_NULLPTR, 0), 0);
-    sp_must_eq(t, mbedtls_pk_parse_key(&server.pk, (const unsigned char*)fetch_key, sp_cstr_len(fetch_key) + 1, SP_NULLPTR, 0, mbedtls_ctr_drbg_random, &server.drbg), 0);
-    sp_must_eq(t, mbedtls_ssl_config_defaults(&server.conf, MBEDTLS_SSL_IS_SERVER, MBEDTLS_SSL_TRANSPORT_STREAM, MBEDTLS_SSL_PRESET_DEFAULT), 0);
-    mbedtls_ssl_conf_rng(&server.conf, mbedtls_ctr_drbg_random, &server.drbg);
-    sp_must_eq(t, mbedtls_ssl_conf_own_cert(&server.conf, &server.crt, &server.pk), 0);
-  }
-
   sp_thread_t thread = sp_zero;
   sp_thread_init(&thread, server_thread, &server);
-
-  sp_tls_trust_t trust = sp_zero;
-  sp_tls_trust_init(&trust, mem);
-  trust.backend = SP_TLS_BACKEND_ANCHORS;
-  if (c->tls && !c->untrusted) {
-    sp_must_eq(t, mbedtls_x509_crt_parse((mbedtls_x509_crt*)trust.anchors, (const unsigned char*)fetch_cert, sp_cstr_len(fetch_cert) + 1), 0);
-  }
-  sp_tls_mbedtls_t client = sp_zero;
-  sp_tls_mbedtls_init(&client, &trust);
 
   sp_io_dyn_mem_writer_t body = sp_zero;
   sp_io_dyn_mem_writer_init(mem, &body);
@@ -711,28 +580,32 @@ static sp_err_t run(sp_test_t* t, test_t* c) {
     url = sp_cstr_as_str(c->url);
   }
   else {
-    url = sp_fmt(mem, "{}://127.0.0.1:{}{}", sp_fmt_cstr(c->tls ? "https" : "http"), sp_fmt_cstr(port), sp_fmt_cstr(c->path ? c->path : "/")).value;
+    url = sp_fmt(mem, "http://127.0.0.1:{}{}", sp_fmt_cstr(port), sp_fmt_cstr(c->path ? c->path : "/")).value;
   }
 
   sp_http_request_t request = {
     .url    = url,
-    .tls    = &client.base,
     .sink   = &body.base,
     .method = c->method,
     .proxy  = c->proxy ? sp_fmt(mem, "127.0.0.1:{}", sp_fmt_cstr(port)).value : sp_str_lit(""),
     .no_proxy = !c->proxy, // isolate the suite from proxies in the developer's environment
-    .connect_timeout_ms = c->connect_timeout_ms,
     .io_timeout_ms = c->io_timeout_ms,
   };
   if (c->resolve == RESOLVE_LOCAL)  request.resolver = (sp_http_resolver_t) { .resolve = resolve_local };
   if (c->resolve == RESOLVE_REFUSE) request.resolver = (sp_http_resolver_t) { .resolve = resolve_refuse };
   if (c->payload)      request.payload = sp_cstr_as_str(c->payload);
   if (c->content_type) request.content_type = sp_cstr_as_str(c->content_type);
+  sp_http_header_t headers [HTTP_TEST_MAX_HEADERS];
+  u32 num_headers = 0;
   sp_carr_for(c->headers, it) {
     if (!c->headers[it].name) break;
-    request.headers[it].name = sp_cstr_as_str(c->headers[it].name);
-    if (c->headers[it].value) request.headers[it].value = sp_cstr_as_str(c->headers[it].value);
+    headers[num_headers++] = (sp_http_header_t) {
+      .name = sp_cstr_as_str(c->headers[it].name),
+      .value = c->headers[it].value ? sp_cstr_as_str(c->headers[it].value) : sp_str_lit(""),
+    };
   }
+  request.headers = headers;
+  request.num_headers = num_headers;
 
   sp_http_response_t response = sp_zero;
   sp_http_error_t err = sp_http_fetch(mem, request, &response);
@@ -740,14 +613,19 @@ static sp_err_t run(sp_test_t* t, test_t* c) {
   sp_expect_eq(t, (s32)err, (s32)c->expect.err);
   if (c->expect.status) sp_expect_eq(t, response.status, c->expect.status);
   if (c->expect.body) sp_expect_str_eq_c(t, sp_io_dyn_mem_writer_as_str(&body), c->expect.body);
-  if (c->expect.content_type) sp_expect_str_eq_c(t, response.content_type, c->expect.content_type);
-  if (c->expect.location) sp_expect_str_eq_c(t, response.location, c->expect.location);
+  sp_carr_for(c->expect.headers, it) {
+    if (!c->expect.headers[it].name) break;
+    sp_test_kv_c(t, "header", c->expect.headers[it].name);
+    sp_expect_str_eq_c(t, sp_http_headers_find(response.headers, sp_cstr_as_str(c->expect.headers[it].name)), c->expect.headers[it].value);
+  }
+  sp_test_kv_clear(t, "header");
 
   sp_atomic_s32_store(&server.stop, 1, SP_ATOMIC_SEQ_CST);
-  mbedtls_net_context poke;
-  mbedtls_net_init(&poke);
-  mbedtls_net_connect(&poke, "127.0.0.1", port, MBEDTLS_NET_PROTO_TCP);
-  mbedtls_net_free(&poke);
+  sp_sys_socket_t poke = SP_SYS_INVALID_SOCKET;
+  if (sp_sys_socket_open(&poke, (sp_sys_handle_desc_t) { SP_SYS_BLOCKING }) == SP_OK) {
+    sp_sys_socket_connect(poke, (sp_sys_ipv4_t) { .octets = { 127, 0, 0, 1 }, .port = port_value });
+    sp_sys_socket_close(poke);
+  }
   sp_thread_join(&thread);
 
   sp_str_t captured = sp_str(server.captured, server.captured_len);
@@ -763,15 +641,7 @@ static sp_err_t run(sp_test_t* t, test_t* c) {
   }
   sp_test_kv_clear(t, "needle");
 
-  mbedtls_net_free(&server.listen);
-  if (c->tls) {
-    mbedtls_ssl_config_free(&server.conf);
-    mbedtls_pk_free(&server.pk);
-    mbedtls_x509_crt_free(&server.crt);
-    mbedtls_ctr_drbg_free(&server.drbg);
-    mbedtls_entropy_free(&server.entropy);
-  }
-  sp_tls_trust_free(&trust);
+  sp_sys_socket_close(server.listener);
   return SP_OK;
 }
 

--- a/test/http/head.c
+++ b/test/http/head.c
@@ -2,69 +2,85 @@
 
 typedef struct {
   sp_http_error_t err;
-  s32            status;
-  const c8*      location;
-  const c8*      content_type;
-  bool           chunked;
-  bool           has_length;
-  u64            length;
+  s32             status;
+  header_t        headers [HTTP_TEST_MAX_HEADERS];
 } expect_t;
 
 typedef struct {
   const c8* name;
   const c8* head;
+  u32       pad_headers;
   expect_t  expect;
 } test_t;
 
 static const test_t tests [] = {
   {
-    .name = "content_length",
-    .head = "HTTP/1.1 200 OK\r\nContent-Length: 12",
-    .expect = { .status = 200, .has_length = true, .length = 12 },
-  },
-  {
-    .name = "duplicate_equal_lengths",
-    .head = "HTTP/1.1 200 OK\r\ncontent-length: 12\r\ncontent-length: 12",
-    .expect = { .status = 200, .has_length = true, .length = 12 },
-  },
-  {
-    .name = "location",
-    .head = "HTTP/1.1 301 Moved Permanently\r\nLocation: https://example.com/new",
-    .expect = { .status = 301, .location = "https://example.com/new" },
-  },
-  {
-    .name = "chunked",
-    .head = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked",
-    .expect = { .status = 200, .chunked = true },
-  },
-  {
-    .name = "te_list_chunked",
-    .head = "HTTP/1.1 200 OK\r\nTransfer-Encoding: GZIP, Chunked",
-    .expect = { .status = 200, .chunked = true },
-  },
-  {
-    .name = "content_type_params",
-    .head = "HTTP/1.1 200 OK\r\nContent-Type: application/json; charset=utf-8\r\nContent-Length: 2",
-    .expect = { .status = 200, .content_type = "application/json; charset=utf-8", .has_length = true, .length = 2 },
-  },
-  {
-    .name = "no_headers_204",
+    .name = "status_only",
     .head = "HTTP/1.1 204 No Content",
     .expect = { .status = 204 },
   },
   {
-    .name = "conflicting_lengths",
-    .head = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nContent-Length: 9",
+    .name = "status_without_reason",
+    .head = "HTTP/1.1 200",
+    .expect = { .status = 200 },
+  },
+  {
+    .name = "http_1_0_response",
+    .head = "HTTP/1.0 200 OK\r\nX: y",
+    .expect = { .status = 200, .headers = { { "X", "y" } } },
+  },
+  {
+    .name = "headers_kept_in_order",
+    .head = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nX-Custom: abc\r\nServer: A",
+    .expect = {
+      .status = 200,
+      .headers = { { "Content-Type", "text/html" }, { "X-Custom", "abc" }, { "Server", "A" } },
+    },
+  },
+  {
+    .name = "duplicate_names_kept",
+    .head = "HTTP/1.1 200 OK\r\nX: 1\r\nX: 2",
+    .expect = { .status = 200, .headers = { { "X", "1" }, { "X", "2" } } },
+  },
+  {
+    .name = "value_trimmed",
+    .head = "HTTP/1.1 200 OK\r\nX:   spaced   ",
+    .expect = { .status = 200, .headers = { { "X", "spaced" } } },
+  },
+  {
+    .name = "empty_value",
+    .head = "HTTP/1.1 200 OK\r\nX:",
+    .expect = { .status = 200, .headers = { { "X", "" } } },
+  },
+  {
+    .name = "content_type_params",
+    .head = "HTTP/1.1 200 OK\r\nContent-Type: application/json; charset=utf-8",
+    .expect = { .status = 200, .headers = { { "Content-Type", "application/json; charset=utf-8" } } },
+  },
+  {
+    .name = "many_headers_ok",
+    .head = "HTTP/1.1 200 OK",
+    .pad_headers = 100,
+    .expect = { .status = 200 },
+  },
+  {
+    .name = "header_without_colon",
+    .head = "HTTP/1.1 200 OK\r\ngarbage",
     .expect = { .err = SP_HTTP_ERR_PROTOCOL },
   },
   {
-    .name = "length_not_numeric",
-    .head = "HTTP/1.1 200 OK\r\nContent-Length: abc",
+    .name = "header_name_with_space",
+    .head = "HTTP/1.1 200 OK\r\nBad Name: x",
     .expect = { .err = SP_HTTP_ERR_PROTOCOL },
   },
   {
-    .name = "te_not_chunked",
-    .head = "HTTP/1.1 200 OK\r\nTransfer-Encoding: gzip",
+    .name = "header_name_empty",
+    .head = "HTTP/1.1 200 OK\r\n: x",
+    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
+  },
+  {
+    .name = "header_value_with_bare_cr",
+    .head = "HTTP/1.1 200 OK\r\nX: a\rb",
     .expect = { .err = SP_HTTP_ERR_PROTOCOL },
   },
   {
@@ -83,6 +99,16 @@ static const test_t tests [] = {
     .expect = { .err = SP_HTTP_ERR_PROTOCOL },
   },
   {
+    .name = "status_too_large",
+    .head = "HTTP/1.1 9999 Huh",
+    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
+  },
+  {
+    .name = "status_too_small",
+    .head = "HTTP/1.1 42 Answer",
+    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
+  },
+  {
     .name = "empty",
     .head = "",
     .expect = { .err = SP_HTTP_ERR_PROTOCOL },
@@ -90,18 +116,34 @@ static const test_t tests [] = {
 };
 
 static sp_err_t run(sp_test_t* t, test_t* c) {
-  sp_http_head_t head = sp_zero;
-  sp_http_error_t err = sp_http_parse_head(sp_cstr_as_str(c->head), &head);
+  sp_mem_t mem = sp_test_arena(t);
+  sp_str_t head = sp_cstr_as_str(c->head);
+  if (c->pad_headers) {
+    sp_io_dyn_mem_writer_t b = sp_zero;
+    sp_io_dyn_mem_writer_init(mem, &b);
+    sp_io_write_str(&b.base, head, SP_NULLPTR);
+    sp_for(it, c->pad_headers) {
+      sp_fmt_io(&b.base, "\r\nP{}: v", sp_fmt_uint(it));
+    }
+    head = sp_io_dyn_mem_writer_as_str(&b);
+  }
+
+  sp_http_response_head_t parsed = sp_zero;
+  sp_http_error_t err = sp_http_response_head_parse(head, &parsed);
   sp_expect_eq(t, (s32)err, (s32)c->expect.err);
   if (err != SP_HTTP_OK || c->expect.err != SP_HTTP_OK) return SP_OK;
 
-  sp_expect_eq(t, head.status, c->expect.status);
-  sp_expect_eq(t, head.chunked, c->expect.chunked);
-  sp_expect_eq(t, head.has_length, c->expect.has_length);
-  sp_expect_eq(t, head.length, c->expect.length);
-  sp_expect_str_eq(t, head.location, sp_cstr_as_str(c->expect.location));
-  sp_expect_str_eq(t, head.content_type, sp_cstr_as_str(c->expect.content_type));
-  return SP_OK;
+  sp_expect_eq(t, parsed.status, c->expect.status);
+  if (c->pad_headers) {
+    u32 count = 0;
+    sp_http_headers_it_t it = sp_http_headers_it(parsed.headers);
+    sp_http_header_t header = sp_zero;
+    while (sp_http_headers_it_next(&it, &header)) count++;
+    sp_expect_eq(t, count, c->pad_headers);
+    return SP_OK;
+  }
+
+  return expect_headers(t, parsed.headers, c->expect.headers, HTTP_TEST_MAX_HEADERS);
 }
 
 sp_test_each_fn(http, head, test_t, tests, run);

--- a/test/http/headers.c
+++ b/test/http/headers.c
@@ -1,0 +1,100 @@
+#include "http.h"
+
+typedef struct {
+  sp_http_error_t check;
+  header_t        gets [HTTP_TEST_MAX_HEADERS]; // name looked up via find, value expected; missing names expect ""
+} expect_t;
+
+typedef struct {
+  const c8* name;
+  header_t  headers [HTTP_TEST_MAX_HEADERS];
+  expect_t  expect;
+} test_t;
+
+static const test_t tests [] = {
+  {
+    .name = "find_exact",
+    .headers = { { "X-A", "1" } },
+    .expect = { .gets = { { "X-A", "1" } } },
+  },
+  {
+    .name = "find_case_insensitive",
+    .headers = { { "Content-Type", "t" } },
+    .expect = { .gets = { { "content-type", "t" }, { "CONTENT-TYPE", "t" } } },
+  },
+  {
+    .name = "find_missing",
+    .headers = { { "X", "1" } },
+    .expect = { .gets = { { "Y", "" } } },
+  },
+  {
+    .name = "find_first_of_duplicates",
+    .headers = { { "X", "1" }, { "X", "2" } },
+    .expect = { .gets = { { "X", "1" } } },
+  },
+  {
+    .name = "check_ok",
+    .headers = { { "X-A", "abc" }, { "X-B", "a\tb" } },
+  },
+  {
+    .name = "check_crlf_value",
+    .headers = { { "X", "a\r\nEvil: 1" } },
+    .expect = { .check = SP_HTTP_ERR_BAD_CONFIG },
+  },
+  {
+    .name = "check_lone_lf_value",
+    .headers = { { "X", "a\nb" } },
+    .expect = { .check = SP_HTTP_ERR_BAD_CONFIG },
+  },
+  {
+    .name = "check_name_with_space",
+    .headers = { { "X Y", "1" } },
+    .expect = { .check = SP_HTTP_ERR_BAD_CONFIG },
+  },
+  {
+    .name = "check_name_with_colon",
+    .headers = { { "X:", "1" } },
+    .expect = { .check = SP_HTTP_ERR_BAD_CONFIG },
+  },
+  {
+    .name = "check_name_with_paren",
+    .headers = { { "X(Y)", "1" } },
+    .expect = { .check = SP_HTTP_ERR_BAD_CONFIG },
+  },
+  {
+    .name = "check_empty_name",
+    .headers = { { "", "1" } },
+    .expect = { .check = SP_HTTP_ERR_BAD_CONFIG },
+  },
+};
+
+static sp_err_t run(sp_test_t* t, test_t* c) {
+  sp_mem_t mem = sp_test_arena(t);
+
+  sp_http_header_t headers [HTTP_TEST_MAX_HEADERS];
+  u32 count = header_count(c->headers, HTTP_TEST_MAX_HEADERS);
+  sp_for(it, count) {
+    headers[it] = (sp_http_header_t) {
+      .name = sp_cstr_as_str(c->headers[it].name),
+      .value = sp_cstr_as_str(c->headers[it].value),
+    };
+  }
+
+  sp_expect_eq(t, (s32)sp_http_headers_check(headers, count), (s32)c->expect.check);
+  if (c->expect.check != SP_HTTP_OK) return SP_OK;
+
+  sp_str_t lines = header_lines(mem, c->headers, HTTP_TEST_MAX_HEADERS);
+  sp_for(it, HTTP_TEST_MAX_HEADERS) {
+    if (!c->expect.gets[it].name) break;
+    sp_test_kv_c(t, "find", c->expect.gets[it].name);
+    sp_str_t name = sp_cstr_as_str(c->expect.gets[it].name);
+    sp_expect_str_eq_c(t, sp_http_headers_find(lines, name), c->expect.gets[it].value);
+    // every present header in the gets tables has a non-empty value, so an
+    // empty expectation means the name is absent
+    sp_expect_eq(t, sp_http_headers_has(lines, name), c->expect.gets[it].value[0] != '\0');
+  }
+  sp_test_kv_clear(t, "find");
+  return SP_OK;
+}
+
+sp_test_each_fn(http, headers, test_t, tests, run);

--- a/test/http/http.h
+++ b/test/http/http.h
@@ -10,4 +10,47 @@
 #include "sp/sp_http.h"
 #include "sp/sp_test.h"
 
+#define HTTP_TEST_MAX_HEADERS 4
+
+typedef struct {
+  const c8* name;
+  const c8* value;
+} header_t;
+
+SP_INLINE u32 header_count(const header_t* headers, u32 capacity) {
+  u32 count = 0;
+  sp_for(it, capacity) {
+    if (!headers[it].name) break;
+    count++;
+  }
+  return count;
+}
+
+SP_INLINE sp_err_t expect_headers(sp_test_t* t, sp_str_t headers, const header_t* expected, u32 capacity) {
+  u32 count = header_count(expected, capacity);
+  sp_http_headers_it_t it = sp_http_headers_it(headers);
+  sp_http_header_t header = sp_zero;
+  sp_for(at, count) {
+    sp_test_kv_c(t, "header", expected[at].name);
+    sp_must_eq(t, sp_http_headers_it_next(&it, &header), true);
+    sp_expect_str_eq_c(t, header.name, expected[at].name);
+    sp_expect_str_eq_c(t, header.value, expected[at].value);
+  }
+  sp_test_kv_clear(t, "header");
+  sp_must_eq(t, sp_http_headers_it_next(&it, &header), false);
+  return SP_OK;
+}
+
+// header lines as they sit in a parsed head: CRLF-separated, no terminator
+SP_INLINE sp_str_t header_lines(sp_mem_t mem, const header_t* headers, u32 capacity) {
+  sp_io_dyn_mem_writer_t w = sp_zero;
+  sp_io_dyn_mem_writer_init(mem, &w);
+  u32 count = header_count(headers, capacity);
+  sp_for(it, count) {
+    if (it) sp_io_write_str(&w.base, sp_str_lit("\r\n"), SP_NULLPTR);
+    sp_fmt_io(&w.base, "{}: {}", sp_fmt_cstr(headers[it].name), sp_fmt_cstr(headers[it].value));
+  }
+  return sp_io_dyn_mem_writer_as_str(&w);
+}
+
 #endif

--- a/test/http/method.c
+++ b/test/http/method.c
@@ -1,0 +1,41 @@
+#include "http.h"
+
+typedef struct {
+  bool             ok;
+  sp_http_method_t method;
+  const c8*        wire;
+} expect_t;
+
+typedef struct {
+  const c8* name;
+  const c8* input;
+  expect_t  expect;
+} test_t;
+
+static const test_t tests [] = {
+  { .name = "get",       .input = "GET",    .expect = { .ok = true, .method = SP_HTTP_GET, .wire = "GET" } },
+  { .name = "post",      .input = "POST",   .expect = { .ok = true, .method = SP_HTTP_POST, .wire = "POST" } },
+  { .name = "put",       .input = "PUT",    .expect = { .ok = true, .method = SP_HTTP_PUT, .wire = "PUT" } },
+  { .name = "patch",     .input = "PATCH",  .expect = { .ok = true, .method = SP_HTTP_PATCH, .wire = "PATCH" } },
+  { .name = "delete",    .input = "DELETE", .expect = { .ok = true, .method = SP_HTTP_DELETE, .wire = "DELETE" } },
+  { .name = "head",      .input = "HEAD",   .expect = { .ok = true, .method = SP_HTTP_HEAD, .wire = "HEAD" } },
+  // methods are tokens and case-sensitive on the wire
+  { .name = "lowercase", .input = "post" },
+  { .name = "mixed",     .input = "Head" },
+  { .name = "unknown",   .input = "TRACE" },
+  { .name = "prefix",    .input = "GE" },
+  { .name = "empty",     .input = "" },
+};
+
+static sp_err_t run(sp_test_t* t, test_t* c) {
+  sp_http_method_t method = c->expect.method == SP_HTTP_GET ? SP_HTTP_POST : SP_HTTP_GET;
+  bool ok = sp_http_method_parse(sp_cstr_as_str(c->input), &method);
+  sp_expect_eq(t, ok, c->expect.ok);
+  if (!ok || !c->expect.ok) return SP_OK;
+
+  sp_expect_eq(t, (s32)method, (s32)c->expect.method);
+  sp_expect_str_eq_c(t, sp_http_method_name(method), c->expect.wire);
+  return SP_OK;
+}
+
+sp_test_each_fn(http, method, test_t, tests, run);

--- a/test/http/read.c
+++ b/test/http/read.c
@@ -1,0 +1,203 @@
+#include "http.h"
+
+typedef struct {
+  sp_http_error_t err;
+  const c8*       body;
+  const c8*       rest;
+} expect_t;
+
+typedef struct {
+  const c8*           name;
+  const c8*           stream;
+  sp_http_body_kind_t kind;
+  u64                 length;
+  bool                discard; // no sink: body_read drains via sp_io_discard
+  u64                 pull;    // read the body this many bytes at a time through sp_http_body_reader_t
+  expect_t            expect;
+} test_t;
+
+static const test_t tests [] = {
+  {
+    .name = "length_exact",
+    .stream = "helloXX",
+    .kind = SP_HTTP_BODY_LENGTH,
+    .length = 5,
+    .expect = { .body = "hello", .rest = "XX" },
+  },
+  {
+    .name = "length_zero",
+    .stream = "XX",
+    .kind = SP_HTTP_BODY_LENGTH,
+    .expect = { .body = "", .rest = "XX" },
+  },
+  {
+    .name = "length_truncated",
+    .stream = "hello",
+    .kind = SP_HTTP_BODY_LENGTH,
+    .length = 10,
+    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
+  },
+  {
+    .name = "chunked",
+    .stream = "5\r\nhello\r\n6\r\n world\r\n0\r\n\r\nREST",
+    .kind = SP_HTTP_BODY_CHUNKED,
+    .expect = { .body = "hello world", .rest = "REST" },
+  },
+  {
+    .name = "chunked_extension",
+    .stream = "5;ext=1\r\nhello\r\n0\r\n\r\n",
+    .kind = SP_HTTP_BODY_CHUNKED,
+    .expect = { .body = "hello", .rest = "" },
+  },
+  {
+    .name = "chunked_hex_size",
+    .stream = "b\r\nhello world\r\n0\r\n\r\n",
+    .kind = SP_HTTP_BODY_CHUNKED,
+    .expect = { .body = "hello world", .rest = "" },
+  },
+  {
+    .name = "chunked_hex_size_upper",
+    .stream = "B\r\nhello world\r\n0\r\n\r\n",
+    .kind = SP_HTTP_BODY_CHUNKED,
+    .expect = { .body = "hello world", .rest = "" },
+  },
+  {
+    .name = "chunked_size_overflows_u64",
+    .stream = "ffffffffffffffffff\r\nhello\r\n0\r\n\r\n",
+    .kind = SP_HTTP_BODY_CHUNKED,
+    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
+  },
+  {
+    .name = "chunked_data_truncated",
+    .stream = "5\r\nhel",
+    .kind = SP_HTTP_BODY_CHUNKED,
+    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
+  },
+  {
+    .name = "chunked_trailers_consumed",
+    .stream = "5\r\nhello\r\n0\r\nX-T: 1\r\nY: 2\r\n\r\nREST",
+    .kind = SP_HTTP_BODY_CHUNKED,
+    .expect = { .body = "hello", .rest = "REST" },
+  },
+  {
+    .name = "chunked_bad_separator",
+    .stream = "5\r\nhelloXX\r\n0\r\n\r\n",
+    .kind = SP_HTTP_BODY_CHUNKED,
+    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
+  },
+  {
+    .name = "chunked_bad_size",
+    .stream = "zz\r\nhello\r\n0\r\n\r\n",
+    .kind = SP_HTTP_BODY_CHUNKED,
+    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
+  },
+  {
+    .name = "chunked_missing_terminator",
+    .stream = "5\r\nhello\r\n0\r\n",
+    .kind = SP_HTTP_BODY_CHUNKED,
+    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
+  },
+  {
+    .name = "eof",
+    .stream = "hello",
+    .kind = SP_HTTP_BODY_EOF,
+    .expect = { .body = "hello", .rest = "" },
+  },
+  {
+    .name = "none",
+    .stream = "hello",
+    .kind = SP_HTTP_BODY_NONE,
+    .expect = { .body = "", .rest = "hello" },
+  },
+  {
+    .name = "length_discard",
+    .stream = "helloXX",
+    .kind = SP_HTTP_BODY_LENGTH,
+    .length = 5,
+    .discard = true,
+    .expect = { .body = "hello", .rest = "XX" },
+  },
+  {
+    .name = "chunked_discard",
+    .stream = "5\r\nhello\r\n6\r\n world\r\n0\r\n\r\nREST",
+    .kind = SP_HTTP_BODY_CHUNKED,
+    .discard = true,
+    .expect = { .body = "hello world", .rest = "REST" },
+  },
+  {
+    .name = "eof_discard",
+    .stream = "hello",
+    .kind = SP_HTTP_BODY_EOF,
+    .discard = true,
+    .expect = { .body = "hello", .rest = "" },
+  },
+  {
+    .name = "length_truncated_discard",
+    .stream = "hello",
+    .kind = SP_HTTP_BODY_LENGTH,
+    .length = 10,
+    .discard = true,
+    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
+  },
+  {
+    .name = "chunked_pulled",
+    .stream = "5\r\nhello\r\n6\r\n world\r\n0\r\n\r\nREST",
+    .kind = SP_HTTP_BODY_CHUNKED,
+    .pull = 3,
+    .expect = { .body = "hello world", .rest = "REST" },
+  },
+  {
+    .name = "length_pulled",
+    .stream = "helloXX",
+    .kind = SP_HTTP_BODY_LENGTH,
+    .length = 5,
+    .pull = 2,
+    .expect = { .body = "hello", .rest = "XX" },
+  },
+};
+
+static sp_err_t run(sp_test_t* t, test_t* c) {
+  sp_mem_t mem = sp_test_arena(t);
+
+  sp_io_reader_t reader = sp_zero;
+  sp_io_reader_from_mem(&reader, c->stream, sp_cstr_len(c->stream));
+
+  sp_io_dyn_mem_writer_t sink = sp_zero;
+  sp_io_dyn_mem_writer_init(mem, &sink);
+
+  u64 len = 0;
+  sp_http_body_t body = { .kind = c->kind, .length = c->length };
+  sp_http_error_t err = SP_HTTP_OK;
+  if (c->pull) {
+    sp_http_body_reader_t br = sp_zero;
+    sp_http_body_reader_init(&br, &reader, body);
+    u8 buf [8];
+    for (;;) {
+      u64 got = 0;
+      sp_err_t rerr = sp_io_read(&br.base, buf, sp_min(c->pull, sizeof(buf)), &got);
+      sp_io_write(&sink.base, buf, got, SP_NULLPTR);
+      len += got;
+      if (rerr == SP_ERR_IO_EOF) break;
+      if (rerr != SP_OK) {
+        err = br.err != SP_HTTP_OK ? br.err : SP_HTTP_ERR_PROTOCOL;
+        break;
+      }
+    }
+  }
+  else {
+    err = sp_http_body_read(&reader, body, c->discard ? SP_NULLPTR : &sink.base, &len);
+  }
+  sp_expect_eq(t, (s32)err, (s32)c->expect.err);
+  if (err != SP_HTTP_OK || c->expect.err != SP_HTTP_OK) return SP_OK;
+
+  if (!c->discard) sp_expect_str_eq_c(t, sp_io_dyn_mem_writer_as_str(&sink), c->expect.body);
+  sp_expect_eq(t, len, sp_cstr_len(c->expect.body));
+
+  c8 rest [64];
+  u64 rest_len = 0;
+  sp_io_read(&reader, rest, sizeof(rest), &rest_len);
+  sp_expect_str_eq_c(t, sp_str(rest, (u32)rest_len), c->expect.rest);
+  return SP_OK;
+}
+
+sp_test_each_fn(http, read, test_t, tests, run);

--- a/test/http/request.c
+++ b/test/http/request.c
@@ -1,0 +1,99 @@
+#include "http.h"
+
+typedef struct {
+  sp_http_error_t err;
+  const c8*       method;
+  const c8*       target;
+  header_t        headers [HTTP_TEST_MAX_HEADERS];
+} expect_t;
+
+typedef struct {
+  const c8* name;
+  const c8* head;
+  expect_t  expect;
+} test_t;
+
+static const test_t tests [] = {
+  {
+    .name = "get_root",
+    .head = "GET / HTTP/1.1",
+    .expect = { .method = "GET", .target = "/" },
+  },
+  {
+    .name = "headers_kept",
+    .head = "POST /shot HTTP/1.1\r\nHost: A\r\nContent-Length: 4",
+    .expect = {
+      .method = "POST",
+      .target = "/shot",
+      .headers = { { "Host", "A" }, { "Content-Length", "4" } },
+    },
+  },
+  {
+    .name = "http_1_0",
+    .head = "GET / HTTP/1.0",
+    .expect = { .method = "GET", .target = "/" },
+  },
+  {
+    .name = "unknown_method_kept",
+    .head = "BREW /pot HTTP/1.1",
+    .expect = { .method = "BREW", .target = "/pot" },
+  },
+  {
+    .name = "method_case_preserved",
+    .head = "get / HTTP/1.1",
+    .expect = { .method = "get", .target = "/" },
+  },
+  {
+    .name = "query_target",
+    .head = "GET /a?b=c HTTP/1.1",
+    .expect = { .method = "GET", .target = "/a?b=c" },
+  },
+  {
+    .name = "missing_version",
+    .head = "GET /",
+    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
+  },
+  {
+    .name = "bad_version",
+    .head = "GET / HTTP/2",
+    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
+  },
+  {
+    .name = "double_space",
+    .head = "GET  / HTTP/1.1",
+    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
+  },
+  {
+    .name = "empty_method",
+    .head = " / HTTP/1.1",
+    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
+  },
+  {
+    .name = "target_with_control_byte",
+    .head = "GET /\x01 HTTP/1.1",
+    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
+  },
+  {
+    .name = "header_without_colon",
+    .head = "GET / HTTP/1.1\r\ngarbage",
+    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
+  },
+  {
+    .name = "empty",
+    .head = "",
+    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
+  },
+};
+
+static sp_err_t run(sp_test_t* t, test_t* c) {
+  sp_http_request_head_t parsed = sp_zero;
+  sp_http_error_t err = sp_http_request_head_parse(sp_cstr_as_str(c->head), &parsed);
+  sp_expect_eq(t, (s32)err, (s32)c->expect.err);
+  if (err != SP_HTTP_OK || c->expect.err != SP_HTTP_OK) return SP_OK;
+
+  sp_expect_str_eq_c(t, parsed.method, c->expect.method);
+  sp_expect_str_eq_c(t, parsed.target, c->expect.target);
+  return expect_headers(t, parsed.headers, c->expect.headers, HTTP_TEST_MAX_HEADERS);
+}
+
+sp_test_each_fn(http, request, test_t, tests, run);

--- a/test/http/stream.c
+++ b/test/http/stream.c
@@ -1,0 +1,61 @@
+#include "http.h"
+
+typedef struct {
+  sp_http_error_t err;
+  const c8*       head;
+  const c8*       rest;
+} expect_t;
+
+typedef struct {
+  const c8* name;
+  const c8* stream;
+  expect_t  expect;
+} test_t;
+
+static const test_t tests [] = {
+  {
+    .name = "head_with_leftover",
+    .stream = "HTTP/1.1 200 OK\r\nX: y\r\n\r\nBODY",
+    .expect = { .head = "HTTP/1.1 200 OK\r\nX: y", .rest = "BODY" },
+  },
+  {
+    .name = "terminator_at_end",
+    .stream = "GET / HTTP/1.1\r\n\r\n",
+    .expect = { .head = "GET / HTTP/1.1", .rest = "" },
+  },
+  {
+    .name = "empty_head",
+    .stream = "\r\n\r\nrest",
+    .expect = { .head = "", .rest = "rest" },
+  },
+  {
+    .name = "eof_before_terminator",
+    .stream = "HTTP/1.1 200",
+    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
+  },
+  {
+    .name = "empty_stream",
+    .stream = "",
+    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
+  },
+};
+
+static sp_err_t run(sp_test_t* t, test_t* c) {
+  sp_io_reader_t reader = sp_zero;
+  sp_io_reader_from_mem(&reader, c->stream, sp_cstr_len(c->stream));
+
+  sp_str_t head = sp_zero;
+  sp_http_error_t err = sp_http_head_read(&reader, &head);
+  sp_expect_eq(t, (s32)err, (s32)c->expect.err);
+  if (err != SP_HTTP_OK || c->expect.err != SP_HTTP_OK) return SP_OK;
+
+  sp_expect_str_eq_c(t, head, c->expect.head);
+
+  c8 rest [64];
+  u64 rest_len = 0;
+  sp_io_read(&reader, rest, sizeof(rest), &rest_len);
+  sp_expect_str_eq_c(t, sp_str(rest, (u32)rest_len), c->expect.rest);
+  return SP_OK;
+}
+
+sp_test_each_fn(http, stream, test_t, tests, run);

--- a/test/http/tls/fetch.c
+++ b/test/http/tls/fetch.c
@@ -1,0 +1,291 @@
+#define SP_HTTP_IMPLEMENTATION
+#include "sp/sp_http.h"
+#include "sp/sp_test.h"
+
+#if !defined(SP_WIN32)
+#include <signal.h>
+#endif
+
+#define TLS_MAX_STEPS 4
+
+typedef struct {
+  const c8* send;
+  u32       delay_ms;
+} step_t;
+
+typedef struct {
+  sp_http_error_t err;
+  s32             status;
+  const c8*       body;
+} expect_t;
+
+typedef struct {
+  const c8* name;
+  bool      untrusted;       // the client does not anchor the server certificate
+  bool      no_close_notify; // slam the connection shut after playing the script
+  bool      proxy;           // tunnel through the mock server with a plaintext CONNECT preamble
+  const c8* connect_reply;   // reply to CONNECT; defaults to 200
+  u32       io_timeout_ms;
+  step_t    steps [TLS_MAX_STEPS];
+  expect_t  expect;
+  const c8* captured [2];    // substrings that must appear in requests the server received
+} test_t;
+
+static const test_t tests [] = {
+  {
+    .name = "trusted",
+    .steps = { { .send = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello" } },
+    .expect = { .status = 200, .body = "hello" },
+  },
+  {
+    .name = "untrusted",
+    .untrusted = true,
+    .steps = { { .send = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello" } },
+    .expect = { .err = SP_HTTP_ERR_UNTRUSTED },
+  },
+  {
+    .name = "eof_body_close_notify",
+    .steps = { { .send = "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\nhello" } },
+    .expect = { .status = 200, .body = "hello" },
+  },
+  {
+    .name = "eof_body_no_close_notify",
+    .no_close_notify = true,
+    .steps = { { .send = "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\nhello" } },
+    .expect = { .err = SP_HTTP_ERR_PROTOCOL },
+  },
+  {
+    .name = "timeout",
+    .io_timeout_ms = 120,
+    .steps = { { .send = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello", .delay_ms = 1000 } },
+    .expect = { .err = SP_HTTP_ERR_TIMEOUT },
+  },
+  {
+    .name = "proxy_connect",
+    .proxy = true,
+    .steps = { { .send = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello" } },
+    .expect = { .status = 200, .body = "hello" },
+    .captured = { "CONNECT 127.0.0.1:", "GET / HTTP/1.1" },
+  },
+  {
+    .name = "proxy_connect_refused",
+    .proxy = true,
+    .connect_reply = "HTTP/1.1 403 Forbidden\r\n\r\n",
+    .expect = { .err = SP_HTTP_ERR_PROXY },
+  },
+};
+
+static const c8* tls_cert =
+  "-----BEGIN CERTIFICATE-----\n"
+  "MIIBfjCCASWgAwIBAgIUDPglN4zQDNG5UTi2PtR5HoWKNbkwCgYIKoZIzj0EAwIw\n"
+  "FDESMBAGA1UEAwwJMTI3LjAuMC4xMCAXDTI2MDcwMTIyNTA1NloYDzIxMjYwNjA3\n"
+  "MjI1MDU2WjAUMRIwEAYDVQQDDAkxMjcuMC4wLjEwWTATBgcqhkjOPQIBBggqhkjO\n"
+  "PQMBBwNCAAQ2Hl0cVbbPLuko5otFB3zmPXuP0Lpx11IBhV1NM8Zw6kl46p9Qzc/r\n"
+  "ljXgguMNSYS3HV1wGDqZ+PON+S5OO/tUo1MwUTAdBgNVHQ4EFgQUZs7KCxZ9MnDz\n"
+  "rNhwgCN4rZrqHjgwHwYDVR0jBBgwFoAUZs7KCxZ9MnDzrNhwgCN4rZrqHjgwDwYD\n"
+  "VR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNHADBEAiA2wjJs70BXB/E2UgJFteWi\n"
+  "KHJg0TfhR8GmnwycFLKQxwIgfuDjz1eFI6NFseCI92HdSOohKe9uTWjgfYyOw/lH\n"
+  "7uk=\n"
+  "-----END CERTIFICATE-----\n";
+
+static const c8* tls_key =
+  "-----BEGIN PRIVATE KEY-----\n"
+  "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgkOe51G2MRpZ8kyVN\n"
+  "tWv2/RKrkE9WfLCS4zbMvdlNAUOhRANCAAQ2Hl0cVbbPLuko5otFB3zmPXuP0Lpx\n"
+  "11IBhV1NM8Zw6kl46p9Qzc/rljXgguMNSYS3HV1wGDqZ+PON+S5OO/tU\n"
+  "-----END PRIVATE KEY-----\n";
+
+typedef struct {
+  mbedtls_net_context      listen;
+  sp_atomic_s32_t          stop;
+  bool                     no_close_notify;
+  bool                     proxy;
+  const c8*                connect_reply;
+  const step_t*            steps;
+  c8                       captured [8192];
+  u32                      captured_len;
+  mbedtls_ssl_config       conf;
+  mbedtls_x509_crt         crt;
+  mbedtls_pk_context       pk;
+  mbedtls_entropy_context  entropy;
+  mbedtls_ctr_drbg_context drbg;
+} server_t;
+
+static bool mock_send(mbedtls_ssl_context* ssl, mbedtls_net_context* net, const u8* data, u32 len) {
+  u32 sent = 0;
+  while (sent < len) {
+    s32 n = ssl
+      ? mbedtls_ssl_write(ssl, data + sent, len - sent)
+      : mbedtls_net_send(net, data + sent, len - sent);
+    if (n == MBEDTLS_ERR_SSL_WANT_READ || n == MBEDTLS_ERR_SSL_WANT_WRITE) continue;
+    if (n <= 0) return false;
+    sent += (u32)n;
+  }
+  return true;
+}
+
+static bool mock_read_request(server_t* server, mbedtls_ssl_context* ssl, mbedtls_net_context* net) {
+  c8 buf [8192];
+  u32 len = 0;
+  bool ok = false;
+  for (;;) {
+    if (sp_str_find(sp_str(buf, len), sp_str_lit("\r\n\r\n")) != SP_STR_NO_MATCH) {
+      ok = true;
+      break;
+    }
+    if (len == sizeof(buf)) break;
+    s32 n = ssl
+      ? mbedtls_ssl_read(ssl, (u8*)buf + len, sizeof(buf) - len)
+      : mbedtls_net_recv(net, (u8*)buf + len, sizeof(buf) - len);
+    if (n == MBEDTLS_ERR_SSL_WANT_READ || n == MBEDTLS_ERR_SSL_WANT_WRITE) continue;
+    if (n <= 0) break;
+    len += (u32)n;
+  }
+  u32 space = (u32)sizeof(server->captured) - server->captured_len;
+  u32 take = len < space ? len : space;
+  sp_mem_copy(server->captured + server->captured_len, buf, take);
+  server->captured_len += take;
+  return ok;
+}
+
+static void mock_play(mbedtls_ssl_context* ssl, const step_t* steps) {
+  sp_for(it, TLS_MAX_STEPS) {
+    step_t step = steps[it];
+    if (!step.send) break;
+    if (step.delay_ms) sp_sleep_ms((f64)step.delay_ms);
+    if (!mock_send(ssl, SP_NULLPTR, (const u8*)step.send, sp_cstr_len(step.send))) return;
+  }
+}
+
+static s32 server_thread(void* userdata) {
+  server_t* server = (server_t*)userdata;
+  for (;;) {
+    mbedtls_net_context client;
+    mbedtls_net_init(&client);
+    if (mbedtls_net_accept(&server->listen, &client, SP_NULLPTR, 0, SP_NULLPTR) != 0) break;
+    if (sp_atomic_s32_load(&server->stop, SP_ATOMIC_SEQ_CST)) {
+      mbedtls_net_free(&client);
+      break;
+    }
+
+    bool ok = true;
+    if (server->proxy) {
+      ok = mock_read_request(server, SP_NULLPTR, &client);
+      if (ok) {
+        const c8* reply = server->connect_reply ? server->connect_reply : "HTTP/1.1 200 Connection established\r\n\r\n";
+        ok = mock_send(SP_NULLPTR, &client, (const u8*)reply, sp_cstr_len(reply));
+      }
+    }
+
+    mbedtls_ssl_context ssl;
+    mbedtls_ssl_init(&ssl);
+    if (ok) {
+      ok = mbedtls_ssl_setup(&ssl, &server->conf) == 0;
+      if (ok) {
+        mbedtls_ssl_set_bio(&ssl, &client, mbedtls_net_send, mbedtls_net_recv, SP_NULLPTR);
+        s32 rc;
+        while ((rc = mbedtls_ssl_handshake(&ssl)) != 0) {
+          if (rc != MBEDTLS_ERR_SSL_WANT_READ && rc != MBEDTLS_ERR_SSL_WANT_WRITE) {
+            ok = false;
+            break;
+          }
+        }
+      }
+    }
+
+    if (ok) ok = mock_read_request(server, &ssl, &client);
+    if (ok) mock_play(&ssl, server->steps);
+    if (ok && !server->no_close_notify) mbedtls_ssl_close_notify(&ssl);
+    mbedtls_ssl_free(&ssl);
+    mbedtls_net_free(&client);
+  }
+  return 0;
+}
+
+static sp_err_t run(sp_test_t* t, test_t* c) {
+  sp_mem_t mem = sp_test_arena(t);
+#if !defined(SP_WIN32)
+  signal(SIGPIPE, SIG_IGN);
+#endif
+
+  server_t server = sp_zero;
+  mbedtls_net_init(&server.listen);
+  server.no_close_notify = c->no_close_notify;
+  server.proxy = c->proxy;
+  server.connect_reply = c->connect_reply;
+  server.steps = c->steps;
+
+  sp_must_eq(t, mbedtls_net_bind(&server.listen, "127.0.0.1", "0", MBEDTLS_NET_PROTO_TCP), 0);
+  u16 port_value = 0;
+  sp_must_ok(t, sp_sys_socket_local_port((sp_sys_socket_t)server.listen.fd, &port_value));
+  const c8* port = sp_str_to_cstr(mem, sp_fmt(mem, "{}", sp_fmt_uint(port_value)).value);
+
+  mbedtls_x509_crt_init(&server.crt);
+  mbedtls_pk_init(&server.pk);
+  mbedtls_entropy_init(&server.entropy);
+  mbedtls_ctr_drbg_init(&server.drbg);
+  mbedtls_ssl_config_init(&server.conf);
+  sp_must_eq(t, mbedtls_x509_crt_parse(&server.crt, (const unsigned char*)tls_cert, sp_cstr_len(tls_cert) + 1), 0);
+  sp_must_eq(t, mbedtls_ctr_drbg_seed(&server.drbg, mbedtls_entropy_func, &server.entropy, SP_NULLPTR, 0), 0);
+  sp_must_eq(t, mbedtls_pk_parse_key(&server.pk, (const unsigned char*)tls_key, sp_cstr_len(tls_key) + 1, SP_NULLPTR, 0, mbedtls_ctr_drbg_random, &server.drbg), 0);
+  sp_must_eq(t, mbedtls_ssl_config_defaults(&server.conf, MBEDTLS_SSL_IS_SERVER, MBEDTLS_SSL_TRANSPORT_STREAM, MBEDTLS_SSL_PRESET_DEFAULT), 0);
+  mbedtls_ssl_conf_rng(&server.conf, mbedtls_ctr_drbg_random, &server.drbg);
+  sp_must_eq(t, mbedtls_ssl_conf_own_cert(&server.conf, &server.crt, &server.pk), 0);
+
+  sp_tls_trust_t trust = sp_zero;
+  sp_tls_trust_init(&trust, mem);
+  trust.backend = SP_TLS_BACKEND_ANCHORS;
+  if (!c->untrusted) {
+    sp_must_eq(t, mbedtls_x509_crt_parse(trust.anchors, (const unsigned char*)tls_cert, sp_cstr_len(tls_cert) + 1), 0);
+  }
+  sp_tls_mbedtls_t client = sp_zero;
+  sp_tls_mbedtls_init(&client, &trust);
+
+  sp_thread_t thread = sp_zero;
+  sp_thread_init(&thread, server_thread, &server);
+
+  sp_io_dyn_mem_writer_t body = sp_zero;
+  sp_io_dyn_mem_writer_init(mem, &body);
+
+  sp_http_request_t request = {
+    .url    = sp_fmt(mem, "https://127.0.0.1:{}/", sp_fmt_cstr(port)).value,
+    .tls    = &client.base,
+    .sink   = &body.base,
+    .proxy  = c->proxy ? sp_fmt(mem, "127.0.0.1:{}", sp_fmt_cstr(port)).value : sp_str_lit(""),
+    .no_proxy = !c->proxy, // isolate the suite from proxies in the developer's environment
+    .io_timeout_ms = c->io_timeout_ms,
+  };
+
+  sp_http_response_t response = sp_zero;
+  sp_http_error_t err = sp_http_fetch(mem, request, &response);
+
+  sp_expect_eq(t, (s32)err, (s32)c->expect.err);
+  if (c->expect.status) sp_expect_eq(t, response.status, c->expect.status);
+  if (c->expect.body) sp_expect_str_eq_c(t, sp_io_dyn_mem_writer_as_str(&body), c->expect.body);
+
+  sp_atomic_s32_store(&server.stop, 1, SP_ATOMIC_SEQ_CST);
+  mbedtls_net_context poke;
+  mbedtls_net_init(&poke);
+  mbedtls_net_connect(&poke, "127.0.0.1", port, MBEDTLS_NET_PROTO_TCP);
+  mbedtls_net_free(&poke);
+  sp_thread_join(&thread);
+
+  sp_str_t captured = sp_str(server.captured, server.captured_len);
+  sp_carr_for(c->captured, it) {
+    if (!c->captured[it]) continue;
+    sp_test_kv_c(t, "needle", c->captured[it]);
+    sp_expect(t, sp_str_contains(captured, sp_cstr_as_str(c->captured[it])));
+  }
+  sp_test_kv_clear(t, "needle");
+
+  mbedtls_net_free(&server.listen);
+  mbedtls_ssl_config_free(&server.conf);
+  mbedtls_pk_free(&server.pk);
+  mbedtls_x509_crt_free(&server.crt);
+  mbedtls_ctr_drbg_free(&server.drbg);
+  mbedtls_entropy_free(&server.entropy);
+  sp_tls_trust_free(&trust);
+  return SP_OK;
+}
+
+sp_test_each_fn(tls, fetch, test_t, tests, run);

--- a/test/http/write.c
+++ b/test/http/write.c
@@ -1,0 +1,183 @@
+#include "http.h"
+
+typedef enum {
+  WIRE_REQUEST_HEAD,
+  WIRE_RESPONSE_HEAD,
+  WIRE_RESPONSE,
+} wire_kind_t;
+
+typedef struct {
+  sp_http_error_t err;
+  const c8*       wire;
+} expect_t;
+
+typedef struct {
+  const c8*   name;
+  wire_kind_t kind;
+  const c8*   method;
+  const c8*   target;
+  s32         status;
+  header_t    headers [HTTP_TEST_MAX_HEADERS];
+  const c8*   body;
+  expect_t    expect;
+} test_t;
+
+static const test_t tests [] = {
+  {
+    .name = "request_no_headers",
+    .kind = WIRE_REQUEST_HEAD,
+    .method = "GET",
+    .target = "/x",
+    .expect = { .wire = "GET /x HTTP/1.1\r\n\r\n" },
+  },
+  {
+    .name = "request_with_headers",
+    .kind = WIRE_REQUEST_HEAD,
+    .method = "POST",
+    .target = "/shot",
+    .headers = { { "Host", "A" }, { "Content-Length", "4" } },
+    .expect = { .wire = "POST /shot HTTP/1.1\r\nHost: A\r\nContent-Length: 4\r\n\r\n" },
+  },
+  {
+    .name = "request_bad_method",
+    .kind = WIRE_REQUEST_HEAD,
+    .method = "GE T",
+    .target = "/x",
+    .expect = { .err = SP_HTTP_ERR_BAD_CONFIG },
+  },
+  {
+    .name = "request_bad_target",
+    .kind = WIRE_REQUEST_HEAD,
+    .method = "GET",
+    .target = "/x y",
+    .expect = { .err = SP_HTTP_ERR_BAD_CONFIG },
+  },
+  {
+    .name = "request_header_injection",
+    .kind = WIRE_REQUEST_HEAD,
+    .method = "GET",
+    .target = "/x",
+    .headers = { { "X", "a\r\nEvil: 1" } },
+    .expect = { .err = SP_HTTP_ERR_BAD_CONFIG },
+  },
+  {
+    .name = "response_head",
+    .kind = WIRE_RESPONSE_HEAD,
+    .status = 200,
+    .headers = { { "X", "y" } },
+    .expect = { .wire = "HTTP/1.1 200 OK\r\nX: y\r\n\r\n" },
+  },
+  {
+    .name = "response_head_no_content",
+    .kind = WIRE_RESPONSE_HEAD,
+    .status = 204,
+    .expect = { .wire = "HTTP/1.1 204 No Content\r\n\r\n" },
+  },
+  {
+    .name = "response_head_not_found",
+    .kind = WIRE_RESPONSE_HEAD,
+    .status = 404,
+    .expect = { .wire = "HTTP/1.1 404 Not Found\r\n\r\n" },
+  },
+  {
+    .name = "response_head_unknown_status",
+    .kind = WIRE_RESPONSE_HEAD,
+    .status = 599,
+    .expect = { .wire = "HTTP/1.1 599 \r\n\r\n" },
+  },
+  {
+    .name = "response_head_bad_status",
+    .kind = WIRE_RESPONSE_HEAD,
+    .status = 42,
+    .expect = { .err = SP_HTTP_ERR_BAD_CONFIG },
+  },
+  // sp_http_response_head_write leaves framing to the caller, so a caller
+  // Content-Length passes through
+  {
+    .name = "response_head_caller_framing",
+    .kind = WIRE_RESPONSE_HEAD,
+    .status = 200,
+    .headers = { { "Content-Length", "5" } },
+    .expect = { .wire = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\n" },
+  },
+  {
+    .name = "response_header_injection",
+    .kind = WIRE_RESPONSE_HEAD,
+    .status = 200,
+    .headers = { { "X\r\nEvil", "1" } },
+    .expect = { .err = SP_HTTP_ERR_BAD_CONFIG },
+  },
+  {
+    .name = "response_with_body",
+    .kind = WIRE_RESPONSE,
+    .status = 200,
+    .headers = { { "Content-Type", "text/plain" } },
+    .body = "hello",
+    .expect = { .wire = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhello" },
+  },
+  {
+    .name = "response_with_empty_body",
+    .kind = WIRE_RESPONSE,
+    .status = 200,
+    .body = "",
+    .expect = { .wire = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n" },
+  },
+  // sp_http_response_write owns framing, so caller framing headers are a
+  // config error rather than a duplicate on the wire
+  {
+    .name = "response_caller_content_length",
+    .kind = WIRE_RESPONSE,
+    .status = 200,
+    .headers = { { "Content-Length", "5" } },
+    .body = "hello",
+    .expect = { .err = SP_HTTP_ERR_BAD_CONFIG },
+  },
+  {
+    .name = "response_caller_transfer_encoding",
+    .kind = WIRE_RESPONSE,
+    .status = 200,
+    .headers = { { "Transfer-Encoding", "chunked" } },
+    .body = "hello",
+    .expect = { .err = SP_HTTP_ERR_BAD_CONFIG },
+  },
+};
+
+static sp_err_t run(sp_test_t* t, test_t* c) {
+  sp_mem_t mem = sp_test_arena(t);
+
+  sp_http_header_t headers [HTTP_TEST_MAX_HEADERS];
+  u32 count = header_count(c->headers, HTTP_TEST_MAX_HEADERS);
+  sp_for(it, count) {
+    headers[it] = (sp_http_header_t) {
+      .name = sp_cstr_as_str(c->headers[it].name),
+      .value = sp_cstr_as_str(c->headers[it].value),
+    };
+  }
+
+  sp_io_dyn_mem_writer_t out = sp_zero;
+  sp_io_dyn_mem_writer_init(mem, &out);
+
+  sp_http_error_t err = SP_HTTP_OK;
+  switch (c->kind) {
+    case WIRE_REQUEST_HEAD: {
+      err = sp_http_request_head_write(&out.base, sp_cstr_as_str(c->method), sp_cstr_as_str(c->target), headers, count);
+      break;
+    }
+    case WIRE_RESPONSE_HEAD: {
+      err = sp_http_response_head_write(&out.base, c->status, headers, count);
+      break;
+    }
+    case WIRE_RESPONSE: {
+      err = sp_http_response_write(&out.base, c->status, headers, count, sp_cstr_as_str(c->body));
+      break;
+    }
+  }
+
+  sp_expect_eq(t, (s32)err, (s32)c->expect.err);
+  if (err != SP_HTTP_OK || c->expect.err != SP_HTTP_OK) return SP_OK;
+
+  sp_expect_str_eq_c(t, sp_io_dyn_mem_writer_as_str(&out), c->expect.wire);
+  return SP_OK;
+}
+
+sp_test_each_fn(http, write, test_t, tests, run);


### PR DESCRIPTION
there's a bunch of bullshit in this one. basically, switch the body delivery from push based (sp_http_read_body pushes bytes into a writer) to pull based (you own a reader and read bytes whenever you want). then, take all of the utilities (head parsing, headers, body framing, request/response builders) and actually make them utilities

then, test the pure utilities individually. so even though the diff is pretty big, it's mostly refactoring + testing all this shit that already existed

all the http code is still very much a sketch, and this refactor is so that i can actually use it in my game engine. you probably shouldn't use it.