### PR TITLE
msvc: rewrite

### DIFF
--- a/example/msvc.c
+++ b/example/msvc.c
@@ -1,7 +1,6 @@
 #define SP_IMPLEMENTATION
 #include "sp.h"
 
-#define SP_MSVC_IMPLEMENTATION
 #include "sp/sp_msvc.h"
 
 s32 msvc_main(s32 argc, const c8** argv);
@@ -21,11 +20,11 @@ s32 msvc_main(s32 argc, const c8** argv) {
     return 1;
   }
 
-  sp_log("{.fg cyan} Visual Studio installation(s)", sp_fmt_uint(sp_da_size(result.installations)));
+  sp_log("{.cyan} Visual Studio installation(s)", sp_fmt_uint(sp_da_size(result.installations)));
   sp_da_for(result.installations, i) {
     sp_msvc_vs_t* vs = &result.installations[i];
     sp_log("");
-    sp_log("  [{.fg yellow}] VS {.fg green}", sp_fmt_uint(i), sp_fmt_str(vs->version.product));
+    sp_log("  [{.yellow}] VS {.green}", sp_fmt_uint(i), sp_fmt_str(vs->version.product));
     sp_log("      build:   {}", sp_fmt_str(vs->version.build.str));
     sp_log("      tools:   {}", sp_fmt_str(vs->version.tools.str));
     sp_log("      path:    {}", sp_fmt_str(vs->install_path));
@@ -35,11 +34,11 @@ s32 msvc_main(s32 argc, const c8** argv) {
   }
 
   sp_log("");
-  sp_log("{.fg cyan} Windows SDK(s)", sp_fmt_uint(sp_da_size(result.sdks)));
+  sp_log("{.cyan} Windows SDK(s)", sp_fmt_uint(sp_da_size(result.sdks)));
   sp_da_for(result.sdks, i) {
     sp_msvc_sdk_t* sdk = &result.sdks[i];
     sp_log("");
-    sp_log("  [{.fg yellow}] SDK {.fg green}", sp_fmt_uint(i), sp_fmt_str(sdk->version.str));
+    sp_log("  [{.yellow}] SDK {.green}", sp_fmt_uint(i), sp_fmt_str(sdk->version.str));
     sp_log("      root:       {}", sp_fmt_str(sdk->root));
     sp_log("      lib_um:     {}", sp_fmt_str(sdk->lib_um));
     sp_log("      lib_ucrt:   {}", sp_fmt_str(sdk->lib_ucrt));

--- a/example/msvc.c
+++ b/example/msvc.c
@@ -6,45 +6,55 @@
 s32 msvc_main(s32 argc, const c8** argv);
 SP_MAIN(msvc_main)
 
+void print_entry(const c8* label, sp_str_t value) {
+  sp_log("  {:<8}: {}", sp_fmt_cstr(label), sp_fmt_str(value));
+}
+
+void print_header(const c8* label, sp_str_t version, u32 index) {
+  sp_log("[{.gray}] {} {.green}", sp_fmt_uint(index), sp_fmt_cstr(label), sp_fmt_str(version));
+}
+
 s32 msvc_main(s32 argc, const c8** argv) {
   (void)argc;
   (void)argv;
 
   sp_msvc_t result = sp_zero;
-  sp_mem_heap_t* heap = sp_mem_heap_new();
-  sp_mem_t mem = sp_mem_heap_as_allocator(heap);
-  sp_msvc_err_t err = sp_msvc_find(mem, SP_MSVC_ARCH_X64, &result);
+  sp_msvc_err_t err = sp_msvc_find(&result);
 
   if (err) {
     sp_log("sp_msvc_find failed: {}", sp_fmt_int(err));
     return 1;
   }
 
-  sp_log("{.cyan} Visual Studio installation(s)", sp_fmt_uint(sp_da_size(result.installations)));
-  sp_da_for(result.installations, i) {
+  sp_mem_heap_t* heap = sp_mem_heap_new();
+  sp_mem_t mem = sp_mem_heap_as_allocator(heap);
+
+  sp_log("{} Visual Studio installation(s)", sp_fmt_uint(result.num_installations));
+  sp_for(i, result.num_installations) {
     sp_msvc_vs_t* vs = &result.installations[i];
+    sp_msvc_vs_paths_t paths = sp_msvc_vs_render(mem, vs);
+    print_header("Visual Studio", sp_msvc_version_str(&vs->version.product), i);
+    print_entry("build", sp_msvc_version_str(&vs->version.build));
+    print_entry("tools", sp_msvc_version_str(&vs->version.tools));
+    print_entry("path", sp_msvc_path_str(&vs->install_path));
+    print_entry("lib", paths.lib);
+    print_entry("include", paths.include);
+    print_entry("bin", paths.bin);
     sp_log("");
-    sp_log("  [{.yellow}] VS {.green}", sp_fmt_uint(i), sp_fmt_str(vs->version.product));
-    sp_log("      build:   {}", sp_fmt_str(vs->version.build.str));
-    sp_log("      tools:   {}", sp_fmt_str(vs->version.tools.str));
-    sp_log("      path:    {}", sp_fmt_str(vs->install_path));
-    sp_log("      lib:     {}", sp_fmt_str(vs->lib));
-    sp_log("      include: {}", sp_fmt_str(vs->include));
-    sp_log("      bin:     {}", sp_fmt_str(vs->bin));
   }
 
-  sp_log("");
-  sp_log("{.cyan} Windows SDK(s)", sp_fmt_uint(sp_da_size(result.sdks)));
-  sp_da_for(result.sdks, i) {
+  sp_log("{} Windows SDK(s)", sp_fmt_uint(result.num_sdks));
+  sp_for(i, result.num_sdks) {
     sp_msvc_sdk_t* sdk = &result.sdks[i];
-    sp_log("");
-    sp_log("  [{.yellow}] SDK {.green}", sp_fmt_uint(i), sp_fmt_str(sdk->version.str));
-    sp_log("      root:       {}", sp_fmt_str(sdk->root));
-    sp_log("      lib_um:     {}", sp_fmt_str(sdk->lib_um));
-    sp_log("      lib_ucrt:   {}", sp_fmt_str(sdk->lib_ucrt));
-    sp_log("      inc_ucrt:   {}", sp_fmt_str(sdk->include_ucrt));
-    sp_log("      inc_um:     {}", sp_fmt_str(sdk->include_um));
-    sp_log("      inc_shared: {}", sp_fmt_str(sdk->include_shared));
+    sp_msvc_sdk_paths_t paths = sp_msvc_sdk_render(mem, sdk);
+    print_header("SDK", sp_msvc_version_str(&sdk->version), i);
+    print_entry("root", sp_msvc_path_str(&sdk->root));
+    print_entry("lib_um", paths.lib_um);
+    print_entry("lib_ucrt", paths.lib_ucrt);
+    print_entry("inc_ucrt", paths.include_ucrt);
+    print_entry("inc_um", paths.include_um);
+    print_entry("inc_shared:", paths.include_shared);
+    if (i != result.num_sdks - 1) sp_log("");
   }
 
   return 0;

--- a/sp.h
+++ b/sp.h
@@ -18586,7 +18586,7 @@ static sp_err_t sp_fmt_io_v_ex(sp_io_writer_t* io, sp_str_t fmt, va_list args, s
       if (sp_fmt_peek(&p, 1) == '{') {
         sp_fmt_advance(&p);
         sp_fmt_advance(&p);
-        sp_io_write_c8(io, '{');
+        sp_try(sp_io_write_c8(io, '{'));
         continue;
       }
 
@@ -18627,13 +18627,13 @@ static sp_err_t sp_fmt_io_v_ex(sp_io_writer_t* io, sp_str_t fmt, va_list args, s
       if (sp_fmt_peek(&p, 1) == '}') {
         sp_fmt_advance(&p);
         sp_fmt_advance(&p);
-        sp_io_write_c8(io, '}');
+        sp_try(sp_io_write_c8(io, '}'));
         continue;
       }
       return SP_ERR_FMT_BAD_PLACEHOLDER;
     }
 
-    sp_io_write_c8(io, c);
+    sp_try(sp_io_write_c8(io, c));
     sp_fmt_advance(&p);
   }
 
@@ -18970,34 +18970,34 @@ static sp_err_t sp_fmt_render_ex(sp_io_writer_t* io, sp_fmt_arg_t* arg, sp_fmt_s
     case SP_FMT_ALIGN_NONE:   left_pad = pad; break;
   }
 
-  sp_for(it, left_pad) sp_io_write_c8(io, fill);
+  sp_for(it, left_pad) sp_try(sp_io_write_c8(io, fill));
   switch (sink->kind) {
     case SP_FMT_SINK_PLAIN: {
       sp_for(it, num_dirs) {
-        if (arg->spec.directive.styles[it] == sp_fmt_style_quote) sp_io_write_c8(io, '"');
+        if (arg->spec.directive.styles[it] == sp_fmt_style_quote) sp_try(sp_io_write_c8(io, '"'));
       }
-      sp_io_write_str(io, content, SP_NULLPTR);
+      sp_try(sp_io_write_str(io, content, SP_NULLPTR));
       u8 j = num_dirs;
       while (j--) {
-        if (arg->spec.directive.styles[j] == sp_fmt_style_quote) sp_io_write_c8(io, '"');
+        if (arg->spec.directive.styles[j] == sp_fmt_style_quote) sp_try(sp_io_write_c8(io, '"'));
       }
       break;
     }
     case SP_FMT_SINK_ANSI: {
       sp_for(it, num_dirs) sp_fmt_style_open(io, arg->spec.directive.styles[it], arg);
-      sp_io_write_str(io, content, SP_NULLPTR);
+      sp_try(sp_io_write_str(io, content, SP_NULLPTR));
       bool reset = false;
       u8 j = num_dirs;
       while (j--) {
         sp_fmt_style_t style = arg->spec.directive.styles[j];
         if (style == sp_fmt_style_quote) {
-          sp_io_write_c8(io, '"');
+          sp_try(sp_io_write_c8(io, '"'));
         }
         else if (style == sp_fmt_style_hyperlink) {
-          sp_io_write_cstr(io, "\033]8;;\033\\", SP_NULLPTR);
+          sp_try(sp_io_write_cstr(io, "\033]8;;\033\\", SP_NULLPTR));
         }
         else if (!reset && sp_fmt_style_to_ansi(style)) {
-          sp_io_write_cstr(io, SP_ANSI_RESET, SP_NULLPTR);
+          sp_try(sp_io_write_cstr(io, SP_ANSI_RESET, SP_NULLPTR));
           reset = true;
         }
       }
@@ -19031,7 +19031,7 @@ static sp_err_t sp_fmt_render_ex(sp_io_writer_t* io, sp_fmt_arg_t* arg, sp_fmt_s
       break;
     }
   }
-  sp_for(it, right_pad) sp_io_write_c8(io, fill);
+  sp_for(it, right_pad) sp_try(sp_io_write_c8(io, fill));
   return SP_OK;
 }
 

--- a/sp/sp_msvc.h
+++ b/sp/sp_msvc.h
@@ -34,12 +34,6 @@ typedef struct {
 } sp_msvc_sdk_t;
 
 typedef struct {
-  sp_str_t install_path;
-  sp_str_t build_version;
-  sp_str_t product_line;
-} sp_msvc_state_t;
-
-typedef struct {
   struct {
     sp_str_t product;
     sp_msvc_version_t build;
@@ -58,12 +52,6 @@ typedef struct {
   sp_da(sp_msvc_vs_t) installations;
 } sp_msvc_t;
 
-SP_API sp_msvc_version_t sp_msvc_parse_version(sp_mem_t mem, sp_str_t str);
-SP_API bool              sp_msvc_version_gt(sp_msvc_version_t a, sp_msvc_version_t b);
-SP_API bool              sp_msvc_parse_state(sp_mem_t mem, sp_str_t json, sp_msvc_state_t* out);
-SP_API sp_msvc_sdk_t     sp_msvc_sdk_new(sp_mem_t mem, sp_msvc_arch_t arch, sp_str_t root, sp_str_t version);
-SP_API sp_msvc_vs_t      sp_msvc_vs_new(sp_mem_t mem, sp_msvc_arch_t arch, sp_msvc_state_t state, sp_str_t tools_version);
-
 #if defined(SP_WIN32)
 SP_API sp_msvc_err_t sp_msvc_find(sp_mem_t mem, sp_msvc_arch_t arch, sp_msvc_t* out);
 SP_API void          sp_msvc_free(sp_msvc_t* msvc);
@@ -74,7 +62,26 @@ SP_API void          sp_msvc_free(sp_msvc_t* msvc);
   #define SP_MSVC_IMPLEMENTATION
 #endif
 
-#if defined(SP_MSVC_IMPLEMENTATION)
+#ifndef SP_MSVC_IMPL_H
+#if defined(SP_PRIVATE_HEADER) || defined(SP_MSVC_IMPLEMENTATION)
+#define SP_MSVC_IMPL_H
+
+typedef struct {
+  sp_str_t install_path;
+  sp_str_t build_version;
+  sp_str_t product_line;
+} sp_msvc_state_t;
+
+SP_PRIVATE sp_msvc_version_t sp_msvc_parse_version(sp_mem_t mem, sp_str_t str);
+SP_PRIVATE bool              sp_msvc_version_gt(sp_msvc_version_t a, sp_msvc_version_t b);
+SP_PRIVATE bool              sp_msvc_parse_state(sp_mem_t mem, sp_str_t json, sp_msvc_state_t* out);
+SP_PRIVATE sp_msvc_sdk_t     sp_msvc_sdk_new(sp_mem_t mem, sp_msvc_arch_t arch, sp_str_t root, sp_str_t version);
+SP_PRIVATE sp_msvc_vs_t      sp_msvc_vs_new(sp_mem_t mem, sp_msvc_arch_t arch, sp_msvc_state_t state, sp_str_t tools_version);
+#endif
+#endif // SP_MSVC_IMPL_H
+
+#if defined(SP_MSVC_IMPLEMENTATION) && !defined(SP_MSVC_IMPLEMENTED)
+#define SP_MSVC_IMPLEMENTED
 
 static sp_str_t sp_msvc_arch_name(sp_msvc_arch_t arch) {
   switch (arch) {
@@ -106,7 +113,7 @@ static sp_str_t sp_msvc_json_get_str(sp_mem_t mem, sp_str_t json, sp_str_t key) 
   return sp_io_dyn_mem_writer_as_str(&value);
 }
 
-sp_msvc_version_t sp_msvc_parse_version(sp_mem_t mem, sp_str_t str) {
+SP_PRIVATE sp_msvc_version_t sp_msvc_parse_version(sp_mem_t mem, sp_str_t str) {
   sp_mem_arena_marker_t scratch = sp_mem_begin_scratch_for(mem);
   u32 parts [4] = sp_zero;
   sp_da(sp_str_t) split = sp_str_split_c8(scratch.mem, str, '.');
@@ -125,14 +132,14 @@ sp_msvc_version_t sp_msvc_parse_version(sp_mem_t mem, sp_str_t str) {
   };
 }
 
-bool sp_msvc_version_gt(sp_msvc_version_t a, sp_msvc_version_t b) {
+SP_PRIVATE bool sp_msvc_version_gt(sp_msvc_version_t a, sp_msvc_version_t b) {
   if (a.major != b.major) return a.major > b.major;
   if (a.minor != b.minor) return a.minor > b.minor;
   if (a.build != b.build) return a.build > b.build;
   return a.revision > b.revision;
 }
 
-bool sp_msvc_parse_state(sp_mem_t mem, sp_str_t json, sp_msvc_state_t* out) {
+SP_PRIVATE bool sp_msvc_parse_state(sp_mem_t mem, sp_str_t json, sp_msvc_state_t* out) {
   *out = sp_zero_s(sp_msvc_state_t);
 
   sp_str_t install = sp_msvc_json_get_str(mem, json, sp_str_lit("installationPath"));
@@ -145,7 +152,7 @@ bool sp_msvc_parse_state(sp_mem_t mem, sp_str_t json, sp_msvc_state_t* out) {
   return true;
 }
 
-sp_msvc_sdk_t sp_msvc_sdk_new(sp_mem_t mem, sp_msvc_arch_t arch, sp_str_t root, sp_str_t version) {
+SP_PRIVATE sp_msvc_sdk_t sp_msvc_sdk_new(sp_mem_t mem, sp_msvc_arch_t arch, sp_str_t root, sp_str_t version) {
   sp_str_t arch_name = sp_msvc_arch_name(arch);
 
   return (sp_msvc_sdk_t) {
@@ -159,7 +166,7 @@ sp_msvc_sdk_t sp_msvc_sdk_new(sp_mem_t mem, sp_msvc_arch_t arch, sp_str_t root, 
   };
 }
 
-sp_msvc_vs_t sp_msvc_vs_new(sp_mem_t mem, sp_msvc_arch_t arch, sp_msvc_state_t state, sp_str_t tools_version) {
+SP_PRIVATE sp_msvc_vs_t sp_msvc_vs_new(sp_mem_t mem, sp_msvc_arch_t arch, sp_msvc_state_t state, sp_str_t tools_version) {
   sp_str_t arch_name = sp_msvc_arch_name(arch);
   sp_str_t tools = sp_fmt(mem, "{}/VC/Tools/MSVC/{}", sp_fmt_str(state.install_path), sp_fmt_str(tools_version)).value;
 

--- a/sp/sp_msvc.h
+++ b/sp/sp_msvc.h
@@ -91,13 +91,39 @@ static sp_str_t sp_msvc_arch_name(sp_msvc_arch_t arch) {
   SP_UNREACHABLE_RETURN(sp_str_lit("x64"));
 }
 
+static u32 sp_msvc_json_skip_ws(sp_str_t json, u32 it) {
+  while (it < json.len) {
+    c8 c = json.data[it];
+    if (c != ' ' && c != '\t' && c != '\n' && c != '\r') break;
+    it++;
+  }
+  return it;
+}
+
 static sp_str_t sp_msvc_json_get_str(sp_mem_t mem, sp_str_t json, sp_str_t key) {
   sp_mem_arena_marker_t scratch = sp_mem_begin_scratch_for(mem);
-  sp_str_t needle = sp_fmt(scratch.mem, "\"{}\":\"", sp_fmt_str(key)).value;
-  s32 pos = sp_str_find(json, needle);
-  u32 start = (u32)pos + needle.len;
+  sp_str_t needle = sp_fmt(scratch.mem, "\"{}\"", sp_fmt_str(key)).value;
+
+  u32 cursor = 0;
+  u32 start = 0;
+  bool found = false;
+  while (!found && cursor < json.len) {
+    s32 pos = sp_str_find(sp_str_sub(json, (s32)cursor, (s32)(json.len - cursor)), needle);
+    if (pos == SP_STR_NO_MATCH) break;
+
+    u32 it = cursor + (u32)pos + needle.len;
+    cursor = cursor + (u32)pos + 1;
+
+    it = sp_msvc_json_skip_ws(json, it);
+    if (it >= json.len || json.data[it] != ':') continue;
+    it = sp_msvc_json_skip_ws(json, it + 1);
+    if (it >= json.len || json.data[it] != '"') continue;
+
+    start = it + 1;
+    found = true;
+  }
   sp_mem_end_scratch(scratch);
-  if (pos == SP_STR_NO_MATCH) return sp_zero_s(sp_str_t);
+  if (!found) return sp_zero_s(sp_str_t);
 
   sp_io_dyn_mem_writer_t value = sp_zero;
   sp_io_dyn_mem_writer_init(mem, &value);

--- a/sp/sp_msvc.h
+++ b/sp/sp_msvc.h
@@ -36,13 +36,13 @@ typedef enum {
   SP_MSVC_SDK_PATH_INCLUDE_UCRT,
   SP_MSVC_SDK_PATH_INCLUDE_UM,
   SP_MSVC_SDK_PATH_INCLUDE_SHARED,
-} sp_msvc_sdk_path_t;
+} sp_msvc_sdk_path_id_t;
 
 typedef enum {
   SP_MSVC_VS_PATH_LIB,
   SP_MSVC_VS_PATH_INCLUDE,
   SP_MSVC_VS_PATH_BIN,
-} sp_msvc_vs_path_t;
+} sp_msvc_vs_path_id_t;
 
 typedef struct {
   c8 data [SP_MSVC_PATH_MAX];
@@ -99,12 +99,12 @@ typedef struct {
 SP_API sp_str_t sp_msvc_path_str(const sp_msvc_path_t* path);
 SP_API sp_str_t sp_msvc_version_str(const sp_msvc_version_t* version);
 
-SP_API sp_str_t sp_msvc_sdk_path(sp_mem_t mem, const sp_msvc_sdk_t* sdk, sp_msvc_sdk_path_t kind);
-SP_API sp_str_r sp_msvc_sdk_path_buf(c8* buffer, u64 len, const sp_msvc_sdk_t* sdk, sp_msvc_sdk_path_t kind);
-SP_API sp_err_t sp_msvc_sdk_path_w(sp_io_writer_t* io, const sp_msvc_sdk_t* sdk, sp_msvc_sdk_path_t kind);
-SP_API sp_str_t sp_msvc_vs_path(sp_mem_t mem, const sp_msvc_vs_t* vs, sp_msvc_vs_path_t kind);
-SP_API sp_str_r sp_msvc_vs_path_buf(c8* buffer, u64 len, const sp_msvc_vs_t* vs, sp_msvc_vs_path_t kind);
-SP_API sp_err_t sp_msvc_vs_path_w(sp_io_writer_t* io, const sp_msvc_vs_t* vs, sp_msvc_vs_path_t kind);
+SP_API sp_str_t sp_msvc_sdk_path(sp_mem_t mem, const sp_msvc_sdk_t* sdk, sp_msvc_sdk_path_id_t id);
+SP_API sp_str_r sp_msvc_sdk_path_buf(c8* buffer, u64 len, const sp_msvc_sdk_t* sdk, sp_msvc_sdk_path_id_t id);
+SP_API sp_err_t sp_msvc_sdk_path_io(sp_io_writer_t* io, const sp_msvc_sdk_t* sdk, sp_msvc_sdk_path_id_t id);
+SP_API sp_str_t sp_msvc_vs_path(sp_mem_t mem, const sp_msvc_vs_t* vs, sp_msvc_vs_path_id_t id);
+SP_API sp_str_r sp_msvc_vs_path_buf(c8* buffer, u64 len, const sp_msvc_vs_t* vs, sp_msvc_vs_path_id_t id);
+SP_API sp_err_t sp_msvc_vs_path_io(sp_io_writer_t* io, const sp_msvc_vs_t* vs, sp_msvc_vs_path_id_t id);
 
 SP_API sp_msvc_sdk_paths_t sp_msvc_sdk_render(sp_mem_t mem, const sp_msvc_sdk_t* sdk);
 SP_API sp_msvc_vs_paths_t  sp_msvc_vs_render(sp_mem_t mem, const sp_msvc_vs_t* vs);
@@ -308,12 +308,12 @@ SP_PRIVATE sp_msvc_vs_t sp_msvc_vs_new(sp_msvc_arch_t host, sp_msvc_arch_t targe
   };
 }
 
-sp_err_t sp_msvc_sdk_path_w(sp_io_writer_t* io, const sp_msvc_sdk_t* sdk, sp_msvc_sdk_path_t kind) {
+sp_err_t sp_msvc_sdk_path_io(sp_io_writer_t* io, const sp_msvc_sdk_t* sdk, sp_msvc_sdk_path_id_t id) {
   sp_str_t root = sp_msvc_path_str(&sdk->root);
   sp_str_t version = sp_msvc_version_str(&sdk->version);
   sp_str_t arch = sp_msvc_arch_to_str(sdk->arch);
 
-  switch (kind) {
+  switch (id) {
     case SP_MSVC_SDK_PATH_LIB_UM:         return sp_fmt_io(io, "{}/Lib/{}/um/{}",      sp_fmt_str(root), sp_fmt_str(version), sp_fmt_str(arch));
     case SP_MSVC_SDK_PATH_LIB_UCRT:       return sp_fmt_io(io, "{}/Lib/{}/ucrt/{}",    sp_fmt_str(root), sp_fmt_str(version), sp_fmt_str(arch));
     case SP_MSVC_SDK_PATH_INCLUDE_UCRT:   return sp_fmt_io(io, "{}/Include/{}/ucrt",   sp_fmt_str(root), sp_fmt_str(version));
@@ -323,51 +323,51 @@ sp_err_t sp_msvc_sdk_path_w(sp_io_writer_t* io, const sp_msvc_sdk_t* sdk, sp_msv
   SP_UNREACHABLE_RETURN(SP_ERR);
 }
 
-sp_str_r sp_msvc_sdk_path_buf(c8* buffer, u64 len, const sp_msvc_sdk_t* sdk, sp_msvc_sdk_path_t kind) {
+sp_str_r sp_msvc_sdk_path_buf(c8* buffer, u64 len, const sp_msvc_sdk_t* sdk, sp_msvc_sdk_path_id_t id) {
   sp_io_mem_writer_t io = sp_zero;
   sp_io_mem_writer_from_buffer(&io, buffer, len);
 
   sp_str_r result = sp_zero;
-  result.err = sp_msvc_sdk_path_w(&io.base, sdk, kind);
+  result.err = sp_msvc_sdk_path_io(&io.base, sdk, id);
   if (!result.err) result.value = sp_io_mem_writer_as_str(&io);
   return result;
 }
 
-sp_str_t sp_msvc_sdk_path(sp_mem_t mem, const sp_msvc_sdk_t* sdk, sp_msvc_sdk_path_t kind) {
+sp_str_t sp_msvc_sdk_path(sp_mem_t mem, const sp_msvc_sdk_t* sdk, sp_msvc_sdk_path_id_t id) {
   sp_io_dyn_mem_writer_t io = sp_zero;
   sp_io_dyn_mem_writer_init(mem, &io);
-  sp_msvc_sdk_path_w(&io.base, sdk, kind);
+  sp_msvc_sdk_path_io(&io.base, sdk, id);
   return sp_io_dyn_mem_writer_as_str(&io);
 }
 
-sp_err_t sp_msvc_vs_path_w(sp_io_writer_t* io, const sp_msvc_vs_t* vs, sp_msvc_vs_path_t kind) {
+sp_err_t sp_msvc_vs_path_io(sp_io_writer_t* io, const sp_msvc_vs_t* vs, sp_msvc_vs_path_id_t id) {
   sp_str_t install = sp_msvc_path_str(&vs->install_path);
   sp_str_t tools = sp_msvc_version_str(&vs->version.tools);
   sp_str_t host = sp_msvc_arch_to_str(vs->host);
   sp_str_t target = sp_msvc_arch_to_str(vs->target);
 
-  switch (kind) {
-    case SP_MSVC_VS_PATH_LIB:     return sp_fmt_io(io, "{}/VC/Tools/MSVC/{}/Lib/{}",        sp_fmt_str(install), sp_fmt_str(tools), sp_fmt_str(target));
-    case SP_MSVC_VS_PATH_INCLUDE: return sp_fmt_io(io, "{}/VC/Tools/MSVC/{}/include",       sp_fmt_str(install), sp_fmt_str(tools));
-    case SP_MSVC_VS_PATH_BIN:     return sp_fmt_io(io, "{}/VC/Tools/MSVC/{}/bin/Host{}/{}", sp_fmt_str(install), sp_fmt_str(tools), sp_fmt_str(host), sp_fmt_str(target));
+  switch (id) {
+    case SP_MSVC_VS_PATH_LIB: return sp_fmt_io(io, "{}/VC/Tools/MSVC/{}/Lib/{}", sp_fmt_str(install), sp_fmt_str(tools), sp_fmt_str(target));
+    case SP_MSVC_VS_PATH_INCLUDE: return sp_fmt_io(io, "{}/VC/Tools/MSVC/{}/include", sp_fmt_str(install), sp_fmt_str(tools));
+    case SP_MSVC_VS_PATH_BIN: return sp_fmt_io(io, "{}/VC/Tools/MSVC/{}/bin/Host{}/{}", sp_fmt_str(install), sp_fmt_str(tools), sp_fmt_str(host), sp_fmt_str(target));
   }
   SP_UNREACHABLE_RETURN(SP_ERR);
 }
 
-sp_str_r sp_msvc_vs_path_buf(c8* buffer, u64 len, const sp_msvc_vs_t* vs, sp_msvc_vs_path_t kind) {
+sp_str_r sp_msvc_vs_path_buf(c8* buffer, u64 len, const sp_msvc_vs_t* vs, sp_msvc_vs_path_id_t id) {
   sp_io_mem_writer_t io = sp_zero;
   sp_io_mem_writer_from_buffer(&io, buffer, len);
 
   sp_str_r result = sp_zero;
-  result.err = sp_msvc_vs_path_w(&io.base, vs, kind);
+  result.err = sp_msvc_vs_path_io(&io.base, vs, id);
   if (!result.err) result.value = sp_io_mem_writer_as_str(&io);
   return result;
 }
 
-sp_str_t sp_msvc_vs_path(sp_mem_t mem, const sp_msvc_vs_t* vs, sp_msvc_vs_path_t kind) {
+sp_str_t sp_msvc_vs_path(sp_mem_t mem, const sp_msvc_vs_t* vs, sp_msvc_vs_path_id_t id) {
   sp_io_dyn_mem_writer_t io = sp_zero;
   sp_io_dyn_mem_writer_init(mem, &io);
-  sp_msvc_vs_path_w(&io.base, vs, kind);
+  sp_msvc_vs_path_io(&io.base, vs, id);
   return sp_io_dyn_mem_writer_as_str(&io);
 }
 
@@ -532,7 +532,7 @@ static sp_msvc_err_t sp_msvc_find_installations(sp_msvc_t* msvc, sp_msvc_arch_t 
 
     sp_io_mem_writer_t io = sp_zero;
     sp_io_mem_writer_from_buffer(&io, buf, sizeof(buf));
-    if (sp_msvc_vs_path_w(&io.base, &vs, SP_MSVC_VS_PATH_LIB)) continue;
+    if (sp_msvc_vs_path_io(&io.base, &vs, SP_MSVC_VS_PATH_LIB)) continue;
     if (sp_io_write_str(&io.base, sp_str_lit("/vcruntime.lib"), SP_NULLPTR)) continue;
     if (!sp_fs_exists(sp_io_mem_writer_as_str(&io))) continue;
 

--- a/sp/sp_msvc.h
+++ b/sp/sp_msvc.h
@@ -76,7 +76,7 @@ SP_PRIVATE sp_msvc_version_t sp_msvc_parse_version(sp_mem_t mem, sp_str_t str);
 SP_PRIVATE bool              sp_msvc_version_gt(sp_msvc_version_t a, sp_msvc_version_t b);
 SP_PRIVATE bool              sp_msvc_parse_state(sp_mem_t mem, sp_str_t json, sp_msvc_state_t* out);
 SP_PRIVATE sp_msvc_sdk_t     sp_msvc_sdk_new(sp_mem_t mem, sp_msvc_arch_t arch, sp_str_t root, sp_str_t version);
-SP_PRIVATE sp_msvc_vs_t      sp_msvc_vs_new(sp_mem_t mem, sp_msvc_arch_t arch, sp_msvc_state_t state, sp_str_t tools_version);
+SP_PRIVATE sp_msvc_vs_t      sp_msvc_vs_new(sp_mem_t mem, sp_msvc_arch_t host, sp_msvc_arch_t target, sp_msvc_state_t state, sp_str_t tools_version);
 #endif
 #endif // SP_MSVC_IMPL_H
 
@@ -192,8 +192,8 @@ SP_PRIVATE sp_msvc_sdk_t sp_msvc_sdk_new(sp_mem_t mem, sp_msvc_arch_t arch, sp_s
   };
 }
 
-SP_PRIVATE sp_msvc_vs_t sp_msvc_vs_new(sp_mem_t mem, sp_msvc_arch_t arch, sp_msvc_state_t state, sp_str_t tools_version) {
-  sp_str_t arch_name = sp_msvc_arch_name(arch);
+SP_PRIVATE sp_msvc_vs_t sp_msvc_vs_new(sp_mem_t mem, sp_msvc_arch_t host, sp_msvc_arch_t target, sp_msvc_state_t state, sp_str_t tools_version) {
+  sp_str_t target_name = sp_msvc_arch_name(target);
   sp_str_t tools = sp_fmt(mem, "{}/VC/Tools/MSVC/{}", sp_fmt_str(state.install_path), sp_fmt_str(tools_version)).value;
 
   return (sp_msvc_vs_t) {
@@ -203,9 +203,9 @@ SP_PRIVATE sp_msvc_vs_t sp_msvc_vs_new(sp_mem_t mem, sp_msvc_arch_t arch, sp_msv
       .tools   = sp_msvc_parse_version(mem, tools_version),
     },
     .install_path = sp_str_copy(mem, state.install_path),
-    .lib          = sp_fmt(mem, "{}/Lib/{}", sp_fmt_str(tools), sp_fmt_str(arch_name)).value,
+    .lib          = sp_fmt(mem, "{}/Lib/{}", sp_fmt_str(tools), sp_fmt_str(target_name)).value,
     .include      = sp_fmt(mem, "{}/include", sp_fmt_str(tools)).value,
-    .bin          = sp_fmt(mem, "{}/bin/Hostx64/{}", sp_fmt_str(tools), sp_fmt_str(arch_name)).value,
+    .bin          = sp_fmt(mem, "{}/bin/Host{}/{}", sp_fmt_str(tools), sp_fmt_str(sp_msvc_arch_name(host)), sp_fmt_str(target_name)).value,
   };
 }
 
@@ -261,9 +261,20 @@ static sp_msvc_err_t sp_msvc_find_sdks(sp_msvc_t* msvc, sp_msvc_arch_t arch) {
   return SP_MSVC_OK;
 }
 
+static sp_msvc_arch_t sp_msvc_host_arch() {
+  USHORT process = 0;
+  USHORT native = 0;
+  if (IsWow64Process2(GetCurrentProcess(), &process, &native) && native == IMAGE_FILE_MACHINE_ARM64) {
+    return SP_MSVC_ARCH_ARM64;
+  }
+  return SP_MSVC_ARCH_X64;
+}
+
 static sp_msvc_err_t sp_msvc_find_installations(sp_msvc_t* msvc, sp_msvc_arch_t arch) {
   sp_str_t program_data = sp_os_env_get(sp_str_lit("ProgramData"));
   if (!sp_str_valid(program_data)) return SP_MSVC_ERR_VS_NOT_FOUND;
+
+  sp_msvc_arch_t host = sp_msvc_host_arch();
 
   sp_mem_arena_marker_t scratch = sp_mem_begin_scratch_for(msvc->mem);
 
@@ -293,7 +304,7 @@ static sp_msvc_err_t sp_msvc_find_installations(sp_msvc_t* msvc, sp_msvc_arch_t 
     tools = sp_str_trim(tools);
     if (sp_str_empty(tools)) continue;
 
-    sp_msvc_vs_t vs = sp_msvc_vs_new(msvc->mem, arch, state, tools);
+    sp_msvc_vs_t vs = sp_msvc_vs_new(msvc->mem, host, arch, state, tools);
     if (!sp_fs_exists(sp_fs_join_path(scratch.mem, vs.lib, sp_str_lit("vcruntime.lib")))) continue;
 
     sp_da_push(msvc->installations, vs);

--- a/sp/sp_msvc.h
+++ b/sp/sp_msvc.h
@@ -83,7 +83,7 @@ SP_PRIVATE sp_msvc_vs_t      sp_msvc_vs_new(sp_mem_t mem, sp_msvc_arch_t host, s
 #if defined(SP_MSVC_IMPLEMENTATION) && !defined(SP_MSVC_IMPLEMENTED)
 #define SP_MSVC_IMPLEMENTED
 
-static sp_str_t sp_msvc_arch_name(sp_msvc_arch_t arch) {
+static sp_str_t sp_msvc_arch_to_str(sp_msvc_arch_t arch) {
   switch (arch) {
     case SP_MSVC_ARCH_X64:   { return sp_str_lit("x64"); }
     case SP_MSVC_ARCH_ARM64: { return sp_str_lit("arm64"); }
@@ -101,8 +101,8 @@ static u32 sp_msvc_json_skip_ws(sp_str_t json, u32 it) {
 }
 
 static sp_str_t sp_msvc_json_get_str(sp_mem_t mem, sp_str_t json, sp_str_t key) {
-  sp_mem_arena_marker_t scratch = sp_mem_begin_scratch_for(mem);
-  sp_str_t needle = sp_fmt(scratch.mem, "\"{}\"", sp_fmt_str(key)).value;
+  sp_mem_arena_marker_t s = sp_mem_begin_scratch_for(mem);
+  sp_str_t needle = sp_fmt(s.mem, "\"{}\"", sp_fmt_str(key)).value;
 
   u32 cursor = 0;
   u32 start = 0;
@@ -122,7 +122,7 @@ static sp_str_t sp_msvc_json_get_str(sp_mem_t mem, sp_str_t json, sp_str_t key) 
     start = it + 1;
     found = true;
   }
-  sp_mem_end_scratch(scratch);
+  sp_mem_end_scratch(s);
   if (!found) return sp_zero_s(sp_str_t);
 
   sp_io_dyn_mem_writer_t value = sp_zero;
@@ -179,7 +179,7 @@ SP_PRIVATE bool sp_msvc_parse_state(sp_mem_t mem, sp_str_t json, sp_msvc_state_t
 }
 
 SP_PRIVATE sp_msvc_sdk_t sp_msvc_sdk_new(sp_mem_t mem, sp_msvc_arch_t arch, sp_str_t root, sp_str_t version) {
-  sp_str_t arch_name = sp_msvc_arch_name(arch);
+  sp_str_t arch_name = sp_msvc_arch_to_str(arch);
 
   return (sp_msvc_sdk_t) {
     .version        = sp_msvc_parse_version(mem, version),
@@ -193,7 +193,7 @@ SP_PRIVATE sp_msvc_sdk_t sp_msvc_sdk_new(sp_mem_t mem, sp_msvc_arch_t arch, sp_s
 }
 
 SP_PRIVATE sp_msvc_vs_t sp_msvc_vs_new(sp_mem_t mem, sp_msvc_arch_t host, sp_msvc_arch_t target, sp_msvc_state_t state, sp_str_t tools_version) {
-  sp_str_t target_name = sp_msvc_arch_name(target);
+  sp_str_t target_name = sp_msvc_arch_to_str(target);
   sp_str_t tools = sp_fmt(mem, "{}/VC/Tools/MSVC/{}", sp_fmt_str(state.install_path), sp_fmt_str(tools_version)).value;
 
   return (sp_msvc_vs_t) {
@@ -205,7 +205,7 @@ SP_PRIVATE sp_msvc_vs_t sp_msvc_vs_new(sp_mem_t mem, sp_msvc_arch_t host, sp_msv
     .install_path = sp_str_copy(mem, state.install_path),
     .lib          = sp_fmt(mem, "{}/Lib/{}", sp_fmt_str(tools), sp_fmt_str(target_name)).value,
     .include      = sp_fmt(mem, "{}/include", sp_fmt_str(tools)).value,
-    .bin          = sp_fmt(mem, "{}/bin/Host{}/{}", sp_fmt_str(tools), sp_fmt_str(sp_msvc_arch_name(host)), sp_fmt_str(target_name)).value,
+    .bin          = sp_fmt(mem, "{}/bin/Host{}/{}", sp_fmt_str(tools), sp_fmt_str(sp_msvc_arch_to_str(host)), sp_fmt_str(target_name)).value,
   };
 }
 

--- a/sp/sp_msvc.h
+++ b/sp/sp_msvc.h
@@ -3,6 +3,20 @@
 
 #include "sp.h"
 
+#ifndef SP_MSVC_MAX_SDKS
+  #define SP_MSVC_MAX_SDKS 8
+#endif
+
+#ifndef SP_MSVC_MAX_VS
+  #define SP_MSVC_MAX_VS 8
+#endif
+
+#ifndef SP_MSVC_PATH_MAX
+  #define SP_MSVC_PATH_MAX 512
+#endif
+
+#define SP_MSVC_VERSION_MAX 24
+
 typedef enum {
   SP_MSVC_ARCH_X64,
   SP_MSVC_ARCH_ARM64,
@@ -13,10 +27,31 @@ typedef enum {
   SP_MSVC_ERR_SDK_NOT_FOUND,
   SP_MSVC_ERR_VS_NOT_FOUND,
   SP_MSVC_ERR_REGISTRY,
+  SP_MSVC_ERR_UNSUPPORTED,
 } sp_msvc_err_t;
 
+typedef enum {
+  SP_MSVC_SDK_PATH_LIB_UM,
+  SP_MSVC_SDK_PATH_LIB_UCRT,
+  SP_MSVC_SDK_PATH_INCLUDE_UCRT,
+  SP_MSVC_SDK_PATH_INCLUDE_UM,
+  SP_MSVC_SDK_PATH_INCLUDE_SHARED,
+} sp_msvc_sdk_path_t;
+
+typedef enum {
+  SP_MSVC_VS_PATH_LIB,
+  SP_MSVC_VS_PATH_INCLUDE,
+  SP_MSVC_VS_PATH_BIN,
+} sp_msvc_vs_path_t;
+
 typedef struct {
-  sp_str_t str;
+  c8 data [SP_MSVC_PATH_MAX];
+  u32 len;
+} sp_msvc_path_t;
+
+typedef struct {
+  c8 str [SP_MSVC_VERSION_MAX];
+  u32 str_len;
   u32 major;
   u32 minor;
   u32 build;
@@ -25,37 +60,57 @@ typedef struct {
 
 typedef struct {
   sp_msvc_version_t version;
-  sp_str_t root;
+  sp_msvc_path_t root;
+  sp_msvc_arch_t arch;
+} sp_msvc_sdk_t;
+
+typedef struct {
+  struct {
+    sp_msvc_version_t product;
+    sp_msvc_version_t build;
+    sp_msvc_version_t tools;
+  } version;
+  sp_msvc_path_t install_path;
+  sp_msvc_arch_t host;
+  sp_msvc_arch_t target;
+} sp_msvc_vs_t;
+
+typedef struct {
   sp_str_t lib_um;
   sp_str_t lib_ucrt;
   sp_str_t include_ucrt;
   sp_str_t include_um;
   sp_str_t include_shared;
-} sp_msvc_sdk_t;
+} sp_msvc_sdk_paths_t;
 
 typedef struct {
-  struct {
-    sp_str_t product;
-    sp_msvc_version_t build;
-    sp_msvc_version_t tools;
-  } version;
-  sp_str_t install_path;
   sp_str_t lib;
   sp_str_t include;
   sp_str_t bin;
-} sp_msvc_vs_t;
+} sp_msvc_vs_paths_t;
 
 typedef struct {
-  sp_mem_arena_t* arena;
-  sp_mem_t mem;
-  sp_da(sp_msvc_sdk_t) sdks;
-  sp_da(sp_msvc_vs_t) installations;
+  sp_msvc_sdk_t sdks [SP_MSVC_MAX_SDKS];
+  u32 num_sdks;
+  sp_msvc_vs_t installations [SP_MSVC_MAX_VS];
+  u32 num_installations;
 } sp_msvc_t;
 
-#if defined(SP_WIN32)
-SP_API sp_msvc_err_t sp_msvc_find(sp_mem_t mem, sp_msvc_arch_t arch, sp_msvc_t* out);
-SP_API void          sp_msvc_free(sp_msvc_t* msvc);
-#endif
+SP_API sp_str_t sp_msvc_path_str(const sp_msvc_path_t* path);
+SP_API sp_str_t sp_msvc_version_str(const sp_msvc_version_t* version);
+
+SP_API sp_str_t sp_msvc_sdk_path(sp_mem_t mem, const sp_msvc_sdk_t* sdk, sp_msvc_sdk_path_t kind);
+SP_API sp_str_r sp_msvc_sdk_path_buf(c8* buffer, u64 len, const sp_msvc_sdk_t* sdk, sp_msvc_sdk_path_t kind);
+SP_API sp_err_t sp_msvc_sdk_path_w(sp_io_writer_t* io, const sp_msvc_sdk_t* sdk, sp_msvc_sdk_path_t kind);
+SP_API sp_str_t sp_msvc_vs_path(sp_mem_t mem, const sp_msvc_vs_t* vs, sp_msvc_vs_path_t kind);
+SP_API sp_str_r sp_msvc_vs_path_buf(c8* buffer, u64 len, const sp_msvc_vs_t* vs, sp_msvc_vs_path_t kind);
+SP_API sp_err_t sp_msvc_vs_path_w(sp_io_writer_t* io, const sp_msvc_vs_t* vs, sp_msvc_vs_path_t kind);
+
+SP_API sp_msvc_sdk_paths_t sp_msvc_sdk_render(sp_mem_t mem, const sp_msvc_sdk_t* sdk);
+SP_API sp_msvc_vs_paths_t  sp_msvc_vs_render(sp_mem_t mem, const sp_msvc_vs_t* vs);
+
+SP_API sp_msvc_err_t sp_msvc_find(sp_msvc_t* out);
+SP_API sp_msvc_err_t sp_msvc_find_ex(sp_msvc_arch_t target, sp_msvc_t* out);
 #endif // SP_MSVC_H
 
 #if defined(SP_IMPLEMENTATION) && !defined(SP_MSVC_IMPLEMENTATION)
@@ -67,16 +122,17 @@ SP_API void          sp_msvc_free(sp_msvc_t* msvc);
 #define SP_MSVC_IMPL_H
 
 typedef struct {
-  sp_str_t install_path;
-  sp_str_t build_version;
-  sp_str_t product_line;
+  sp_msvc_path_t install_path;
+  sp_msvc_path_t build_version;
+  sp_msvc_path_t product_line;
 } sp_msvc_state_t;
 
-SP_PRIVATE sp_msvc_version_t sp_msvc_parse_version(sp_mem_t mem, sp_str_t str);
+SP_PRIVATE sp_msvc_path_t    sp_msvc_path_new(sp_str_t str);
+SP_PRIVATE sp_msvc_version_t sp_msvc_parse_version(sp_str_t str);
 SP_PRIVATE bool              sp_msvc_version_gt(sp_msvc_version_t a, sp_msvc_version_t b);
-SP_PRIVATE bool              sp_msvc_parse_state(sp_mem_t mem, sp_str_t json, sp_msvc_state_t* out);
-SP_PRIVATE sp_msvc_sdk_t     sp_msvc_sdk_new(sp_mem_t mem, sp_msvc_arch_t arch, sp_str_t root, sp_str_t version);
-SP_PRIVATE sp_msvc_vs_t      sp_msvc_vs_new(sp_mem_t mem, sp_msvc_arch_t host, sp_msvc_arch_t target, sp_msvc_state_t state, sp_str_t tools_version);
+SP_PRIVATE bool              sp_msvc_parse_state(sp_io_reader_t* reader, sp_msvc_state_t* out);
+SP_PRIVATE sp_msvc_sdk_t     sp_msvc_sdk_new(sp_msvc_arch_t arch, sp_str_t root, sp_str_t version);
+SP_PRIVATE sp_msvc_vs_t      sp_msvc_vs_new(sp_msvc_arch_t host, sp_msvc_arch_t target, const sp_msvc_state_t* state, sp_str_t tools_version);
 #endif
 #endif // SP_MSVC_IMPL_H
 
@@ -91,71 +147,49 @@ static sp_str_t sp_msvc_arch_to_str(sp_msvc_arch_t arch) {
   SP_UNREACHABLE_RETURN(sp_str_lit("x64"));
 }
 
-static u32 sp_msvc_json_skip_ws(sp_str_t json, u32 it) {
-  while (it < json.len) {
-    c8 c = json.data[it];
-    if (c != ' ' && c != '\t' && c != '\n' && c != '\r') break;
-    it++;
-  }
-  return it;
+sp_str_t sp_msvc_path_str(const sp_msvc_path_t* path) {
+  return sp_str(path->data, path->len);
 }
 
-static sp_str_t sp_msvc_json_get_str(sp_mem_t mem, sp_str_t json, sp_str_t key) {
-  sp_mem_arena_marker_t s = sp_mem_begin_scratch_for(mem);
-  sp_str_t needle = sp_fmt(s.mem, "\"{}\"", sp_fmt_str(key)).value;
-
-  u32 cursor = 0;
-  u32 start = 0;
-  bool found = false;
-  while (!found && cursor < json.len) {
-    s32 pos = sp_str_find(sp_str_sub(json, (s32)cursor, (s32)(json.len - cursor)), needle);
-    if (pos == SP_STR_NO_MATCH) break;
-
-    u32 it = cursor + (u32)pos + needle.len;
-    cursor = cursor + (u32)pos + 1;
-
-    it = sp_msvc_json_skip_ws(json, it);
-    if (it >= json.len || json.data[it] != ':') continue;
-    it = sp_msvc_json_skip_ws(json, it + 1);
-    if (it >= json.len || json.data[it] != '"') continue;
-
-    start = it + 1;
-    found = true;
-  }
-  sp_mem_end_scratch(s);
-  if (!found) return sp_zero_s(sp_str_t);
-
-  sp_io_dyn_mem_writer_t value = sp_zero;
-  sp_io_dyn_mem_writer_init(mem, &value);
-  sp_for_range(it, start, json.len) {
-    c8 c = json.data[it];
-    if (c == '"') break;
-    if (c == '\\' && it + 1 < json.len) {
-      it++;
-      c = json.data[it];
-    }
-    sp_io_write_c8(&value.base, c);
-  }
-  return sp_io_dyn_mem_writer_as_str(&value);
+sp_str_t sp_msvc_version_str(const sp_msvc_version_t* version) {
+  return sp_str(version->str, version->str_len);
 }
 
-SP_PRIVATE sp_msvc_version_t sp_msvc_parse_version(sp_mem_t mem, sp_str_t str) {
-  sp_mem_arena_marker_t scratch = sp_mem_begin_scratch_for(mem);
+SP_PRIVATE sp_msvc_path_t sp_msvc_path_new(sp_str_t str) {
+  sp_msvc_path_t path = sp_zero;
+  path.len = sp_min(str.len, SP_MSVC_PATH_MAX);
+  sp_str_copy_to(str, path.data, SP_MSVC_PATH_MAX);
+  return path;
+}
+
+static void sp_msvc_path_normalize(sp_msvc_path_t* path) {
+  sp_for(it, path->len) {
+    if (path->data[it] == '\\') path->data[it] = '/';
+  }
+  if (path->len && path->data[path->len - 1] == '/') {
+    path->len--;
+  }
+}
+
+SP_PRIVATE sp_msvc_version_t sp_msvc_parse_version(sp_str_t str) {
   u32 parts [4] = sp_zero;
-  sp_da(sp_str_t) split = sp_str_split_c8(scratch.mem, str, '.');
-  sp_da_for(split, it) {
-    if (it >= sp_carr_len(parts)) break;
-    parts[it] = sp_parse_u32(split[it]);
+  sp_str_t rest = str;
+  sp_carr_for(parts, it) {
+    if (sp_str_empty(rest)) break;
+    sp_str_pair_t pair = sp_str_cleave_c8(rest, '.');
+    parts[it] = sp_parse_u32(pair.first);
+    rest = pair.second;
   }
-  sp_mem_end_scratch(scratch);
 
-  return (sp_msvc_version_t) {
-    .str      = sp_str_copy(mem, str),
+  sp_msvc_version_t version = {
+    .str_len  = sp_min(str.len, SP_MSVC_VERSION_MAX),
     .major    = parts[0],
     .minor    = parts[1],
     .build    = parts[2],
     .revision = parts[3],
   };
+  sp_str_copy_to(str, version.str, SP_MSVC_VERSION_MAX);
+  return version;
 }
 
 SP_PRIVATE bool sp_msvc_version_gt(sp_msvc_version_t a, sp_msvc_version_t b) {
@@ -165,99 +199,280 @@ SP_PRIVATE bool sp_msvc_version_gt(sp_msvc_version_t a, sp_msvc_version_t b) {
   return a.revision > b.revision;
 }
 
-SP_PRIVATE bool sp_msvc_parse_state(sp_mem_t mem, sp_str_t json, sp_msvc_state_t* out) {
-  *out = sp_zero_s(sp_msvc_state_t);
+typedef struct {
+  sp_msvc_path_t str;
+  bool overflow;
+  bool closed;
+} sp_msvc_json_str_t;
 
-  sp_str_t install = sp_msvc_json_get_str(mem, json, sp_str_lit("installationPath"));
-  sp_str_t build = sp_msvc_json_get_str(mem, json, sp_str_lit("buildVersion"));
-  if (sp_str_empty(install) || sp_str_empty(build)) return false;
-
-  out->install_path = sp_fs_normalize_path(mem, install);
-  out->build_version = build;
-  out->product_line = sp_msvc_json_get_str(mem, json, sp_str_lit("productLineVersion"));
-  return true;
+static bool sp_msvc_json_read_c8(sp_io_reader_t* reader, c8* c) {
+  u64 num_read = 0;
+  if (sp_io_read(reader, c, 1, &num_read)) return false;
+  return num_read == 1;
 }
 
-SP_PRIVATE sp_msvc_sdk_t sp_msvc_sdk_new(sp_mem_t mem, sp_msvc_arch_t arch, sp_str_t root, sp_str_t version) {
-  sp_str_t arch_name = sp_msvc_arch_to_str(arch);
+static bool sp_msvc_json_seek_string(sp_io_reader_t* reader) {
+  c8 c = 0;
+  while (sp_msvc_json_read_c8(reader, &c)) {
+    if (c == '"') return true;
+  }
+  return false;
+}
 
+static sp_msvc_json_str_t sp_msvc_json_read_string(sp_io_reader_t* reader) {
+  sp_msvc_json_str_t result = sp_zero;
+  c8 c = 0;
+  while (sp_msvc_json_read_c8(reader, &c)) {
+    if (c == '"') {
+      result.closed = true;
+      return result;
+    }
+    if (c == '\\' && !sp_msvc_json_read_c8(reader, &c)) {
+      return result;
+    }
+    if (result.str.len < SP_MSVC_PATH_MAX) {
+      result.str.data[result.str.len++] = c;
+    }
+    else {
+      result.overflow = true;
+    }
+  }
+  return result;
+}
+
+static c8 sp_msvc_json_next_token(sp_io_reader_t* reader) {
+  c8 c = 0;
+  while (sp_msvc_json_read_c8(reader, &c)) {
+    if (c != ' ' && c != '\t' && c != '\n' && c != '\r') return c;
+  }
+  return 0;
+}
+
+SP_PRIVATE bool sp_msvc_parse_state(sp_io_reader_t* reader, sp_msvc_state_t* out) {
+  *out = sp_zero_s(sp_msvc_state_t);
+
+  struct {
+    sp_str_t key;
+    sp_msvc_path_t* value;
+    bool seen;
+  } fields [] = {
+    { .key = sp_str_lit("installationPath"),   .value = &out->install_path },
+    { .key = sp_str_lit("buildVersion"),       .value = &out->build_version },
+    { .key = sp_str_lit("productLineVersion"), .value = &out->product_line },
+  };
+
+  u32 num_seen = 0;
+  while (num_seen < sp_carr_len(fields)) {
+    if (!sp_msvc_json_seek_string(reader)) break;
+    sp_msvc_json_str_t key = sp_msvc_json_read_string(reader);
+    if (!key.closed) break;
+    if (sp_msvc_json_next_token(reader) != ':') continue;
+    if (sp_msvc_json_next_token(reader) != '"') continue;
+    sp_msvc_json_str_t value = sp_msvc_json_read_string(reader);
+
+    sp_carr_for(fields, it) {
+      if (fields[it].seen) continue;
+      if (!sp_str_equal(sp_msvc_path_str(&key.str), fields[it].key)) continue;
+      if (value.overflow) return false;
+      *fields[it].value = value.str;
+      fields[it].seen = true;
+      num_seen++;
+      break;
+    }
+
+    if (!value.closed) break;
+  }
+
+  sp_msvc_path_normalize(&out->install_path);
+  return !sp_str_empty(sp_msvc_path_str(&out->install_path)) && !sp_str_empty(sp_msvc_path_str(&out->build_version));
+}
+
+SP_PRIVATE sp_msvc_sdk_t sp_msvc_sdk_new(sp_msvc_arch_t arch, sp_str_t root, sp_str_t version) {
   return (sp_msvc_sdk_t) {
-    .version        = sp_msvc_parse_version(mem, version),
-    .root           = sp_str_copy(mem, root),
-    .lib_um         = sp_fmt(mem, "{}/Lib/{}/um/{}", sp_fmt_str(root), sp_fmt_str(version), sp_fmt_str(arch_name)).value,
-    .lib_ucrt       = sp_fmt(mem, "{}/Lib/{}/ucrt/{}", sp_fmt_str(root), sp_fmt_str(version), sp_fmt_str(arch_name)).value,
-    .include_ucrt   = sp_fmt(mem, "{}/Include/{}/ucrt", sp_fmt_str(root), sp_fmt_str(version)).value,
-    .include_um     = sp_fmt(mem, "{}/Include/{}/um", sp_fmt_str(root), sp_fmt_str(version)).value,
-    .include_shared = sp_fmt(mem, "{}/Include/{}/shared", sp_fmt_str(root), sp_fmt_str(version)).value,
+    .version = sp_msvc_parse_version(version),
+    .root    = sp_msvc_path_new(root),
+    .arch    = arch,
   };
 }
 
-SP_PRIVATE sp_msvc_vs_t sp_msvc_vs_new(sp_mem_t mem, sp_msvc_arch_t host, sp_msvc_arch_t target, sp_msvc_state_t state, sp_str_t tools_version) {
-  sp_str_t target_name = sp_msvc_arch_to_str(target);
-  sp_str_t tools = sp_fmt(mem, "{}/VC/Tools/MSVC/{}", sp_fmt_str(state.install_path), sp_fmt_str(tools_version)).value;
-
+SP_PRIVATE sp_msvc_vs_t sp_msvc_vs_new(sp_msvc_arch_t host, sp_msvc_arch_t target, const sp_msvc_state_t* state, sp_str_t tools_version) {
   return (sp_msvc_vs_t) {
     .version = {
-      .product = sp_str_copy(mem, state.product_line),
-      .build   = sp_msvc_parse_version(mem, state.build_version),
-      .tools   = sp_msvc_parse_version(mem, tools_version),
+      .product = sp_msvc_parse_version(sp_msvc_path_str(&state->product_line)),
+      .build   = sp_msvc_parse_version(sp_msvc_path_str(&state->build_version)),
+      .tools   = sp_msvc_parse_version(tools_version),
     },
-    .install_path = sp_str_copy(mem, state.install_path),
-    .lib          = sp_fmt(mem, "{}/Lib/{}", sp_fmt_str(tools), sp_fmt_str(target_name)).value,
-    .include      = sp_fmt(mem, "{}/include", sp_fmt_str(tools)).value,
-    .bin          = sp_fmt(mem, "{}/bin/Host{}/{}", sp_fmt_str(tools), sp_fmt_str(sp_msvc_arch_to_str(host)), sp_fmt_str(target_name)).value,
+    .install_path = state->install_path,
+    .host         = host,
+    .target       = target,
+  };
+}
+
+sp_err_t sp_msvc_sdk_path_w(sp_io_writer_t* io, const sp_msvc_sdk_t* sdk, sp_msvc_sdk_path_t kind) {
+  sp_str_t root = sp_msvc_path_str(&sdk->root);
+  sp_str_t version = sp_msvc_version_str(&sdk->version);
+  sp_str_t arch = sp_msvc_arch_to_str(sdk->arch);
+
+  switch (kind) {
+    case SP_MSVC_SDK_PATH_LIB_UM:         return sp_fmt_io(io, "{}/Lib/{}/um/{}",      sp_fmt_str(root), sp_fmt_str(version), sp_fmt_str(arch));
+    case SP_MSVC_SDK_PATH_LIB_UCRT:       return sp_fmt_io(io, "{}/Lib/{}/ucrt/{}",    sp_fmt_str(root), sp_fmt_str(version), sp_fmt_str(arch));
+    case SP_MSVC_SDK_PATH_INCLUDE_UCRT:   return sp_fmt_io(io, "{}/Include/{}/ucrt",   sp_fmt_str(root), sp_fmt_str(version));
+    case SP_MSVC_SDK_PATH_INCLUDE_UM:     return sp_fmt_io(io, "{}/Include/{}/um",     sp_fmt_str(root), sp_fmt_str(version));
+    case SP_MSVC_SDK_PATH_INCLUDE_SHARED: return sp_fmt_io(io, "{}/Include/{}/shared", sp_fmt_str(root), sp_fmt_str(version));
+  }
+  SP_UNREACHABLE_RETURN(SP_ERR);
+}
+
+sp_str_r sp_msvc_sdk_path_buf(c8* buffer, u64 len, const sp_msvc_sdk_t* sdk, sp_msvc_sdk_path_t kind) {
+  sp_io_mem_writer_t io = sp_zero;
+  sp_io_mem_writer_from_buffer(&io, buffer, len);
+
+  sp_str_r result = sp_zero;
+  result.err = sp_msvc_sdk_path_w(&io.base, sdk, kind);
+  if (!result.err) result.value = sp_io_mem_writer_as_str(&io);
+  return result;
+}
+
+sp_str_t sp_msvc_sdk_path(sp_mem_t mem, const sp_msvc_sdk_t* sdk, sp_msvc_sdk_path_t kind) {
+  sp_io_dyn_mem_writer_t io = sp_zero;
+  sp_io_dyn_mem_writer_init(mem, &io);
+  sp_msvc_sdk_path_w(&io.base, sdk, kind);
+  return sp_io_dyn_mem_writer_as_str(&io);
+}
+
+sp_err_t sp_msvc_vs_path_w(sp_io_writer_t* io, const sp_msvc_vs_t* vs, sp_msvc_vs_path_t kind) {
+  sp_str_t install = sp_msvc_path_str(&vs->install_path);
+  sp_str_t tools = sp_msvc_version_str(&vs->version.tools);
+  sp_str_t host = sp_msvc_arch_to_str(vs->host);
+  sp_str_t target = sp_msvc_arch_to_str(vs->target);
+
+  switch (kind) {
+    case SP_MSVC_VS_PATH_LIB:     return sp_fmt_io(io, "{}/VC/Tools/MSVC/{}/Lib/{}",        sp_fmt_str(install), sp_fmt_str(tools), sp_fmt_str(target));
+    case SP_MSVC_VS_PATH_INCLUDE: return sp_fmt_io(io, "{}/VC/Tools/MSVC/{}/include",       sp_fmt_str(install), sp_fmt_str(tools));
+    case SP_MSVC_VS_PATH_BIN:     return sp_fmt_io(io, "{}/VC/Tools/MSVC/{}/bin/Host{}/{}", sp_fmt_str(install), sp_fmt_str(tools), sp_fmt_str(host), sp_fmt_str(target));
+  }
+  SP_UNREACHABLE_RETURN(SP_ERR);
+}
+
+sp_str_r sp_msvc_vs_path_buf(c8* buffer, u64 len, const sp_msvc_vs_t* vs, sp_msvc_vs_path_t kind) {
+  sp_io_mem_writer_t io = sp_zero;
+  sp_io_mem_writer_from_buffer(&io, buffer, len);
+
+  sp_str_r result = sp_zero;
+  result.err = sp_msvc_vs_path_w(&io.base, vs, kind);
+  if (!result.err) result.value = sp_io_mem_writer_as_str(&io);
+  return result;
+}
+
+sp_str_t sp_msvc_vs_path(sp_mem_t mem, const sp_msvc_vs_t* vs, sp_msvc_vs_path_t kind) {
+  sp_io_dyn_mem_writer_t io = sp_zero;
+  sp_io_dyn_mem_writer_init(mem, &io);
+  sp_msvc_vs_path_w(&io.base, vs, kind);
+  return sp_io_dyn_mem_writer_as_str(&io);
+}
+
+sp_msvc_sdk_paths_t sp_msvc_sdk_render(sp_mem_t mem, const sp_msvc_sdk_t* sdk) {
+  return (sp_msvc_sdk_paths_t) {
+    .lib_um         = sp_msvc_sdk_path(mem, sdk, SP_MSVC_SDK_PATH_LIB_UM),
+    .lib_ucrt       = sp_msvc_sdk_path(mem, sdk, SP_MSVC_SDK_PATH_LIB_UCRT),
+    .include_ucrt   = sp_msvc_sdk_path(mem, sdk, SP_MSVC_SDK_PATH_INCLUDE_UCRT),
+    .include_um     = sp_msvc_sdk_path(mem, sdk, SP_MSVC_SDK_PATH_INCLUDE_UM),
+    .include_shared = sp_msvc_sdk_path(mem, sdk, SP_MSVC_SDK_PATH_INCLUDE_SHARED),
+  };
+}
+
+sp_msvc_vs_paths_t sp_msvc_vs_render(sp_mem_t mem, const sp_msvc_vs_t* vs) {
+  return (sp_msvc_vs_paths_t) {
+    .lib     = sp_msvc_vs_path(mem, vs, SP_MSVC_VS_PATH_LIB),
+    .include = sp_msvc_vs_path(mem, vs, SP_MSVC_VS_PATH_INCLUDE),
+    .bin     = sp_msvc_vs_path(mem, vs, SP_MSVC_VS_PATH_BIN),
   };
 }
 
 #if defined(SP_WIN32)
 #include <windows.h>
 
-static s32 sp_msvc_sdk_order(const void* a, const void* b) {
-  const sp_msvc_sdk_t* sa = (const sp_msvc_sdk_t*)a;
-  const sp_msvc_sdk_t* sb = (const sp_msvc_sdk_t*)b;
-  if (sp_msvc_version_gt(sa->version, sb->version)) return -1;
-  if (sp_msvc_version_gt(sb->version, sa->version)) return 1;
-  return 0;
+static void sp_msvc_add_sdk(sp_msvc_t* msvc, const sp_msvc_sdk_t* sdk) {
+  u32 at = msvc->num_sdks;
+  while (at && sp_msvc_version_gt(sdk->version, msvc->sdks[at - 1].version)) at--;
+  if (at >= SP_MSVC_MAX_SDKS) return;
+
+  u32 num = sp_min(msvc->num_sdks, SP_MSVC_MAX_SDKS - 1);
+  sp_mem_move(&msvc->sdks[at + 1], &msvc->sdks[at], (num - at) * sizeof(sp_msvc_sdk_t));
+  msvc->sdks[at] = *sdk;
+  msvc->num_sdks = num + 1;
 }
 
-static s32 sp_msvc_vs_order(const void* a, const void* b) {
-  const sp_msvc_vs_t* va = (const sp_msvc_vs_t*)a;
-  const sp_msvc_vs_t* vb = (const sp_msvc_vs_t*)b;
-  if (sp_msvc_version_gt(va->version.build, vb->version.build)) return -1;
-  if (sp_msvc_version_gt(vb->version.build, va->version.build)) return 1;
-  return 0;
+static void sp_msvc_add_vs(sp_msvc_t* msvc, const sp_msvc_vs_t* vs) {
+  u32 at = msvc->num_installations;
+  while (at && sp_msvc_version_gt(vs->version.build, msvc->installations[at - 1].version.build)) at--;
+  if (at >= SP_MSVC_MAX_VS) return;
+
+  u32 num = sp_min(msvc->num_installations, SP_MSVC_MAX_VS - 1);
+  sp_mem_move(&msvc->installations[at + 1], &msvc->installations[at], (num - at) * sizeof(sp_msvc_vs_t));
+  msvc->installations[at] = *vs;
+  msvc->num_installations = num + 1;
+}
+
+static bool sp_msvc_read_state(sp_str_t path, sp_msvc_state_t* state) {
+  sp_io_file_reader_t reader = sp_zero;
+  if (sp_io_file_reader_from_path(&reader, path)) return false;
+
+  u8 buf [4096];
+  sp_io_reader_set_buffer(&reader.base, buf, sizeof(buf));
+  bool ok = sp_msvc_parse_state(&reader.base, state);
+  sp_io_file_reader_close(&reader);
+  return ok;
+}
+
+static sp_str_t sp_msvc_read_tools_version(sp_str_t path, c8* buf, u64 len) {
+  sp_io_file_reader_t reader = sp_zero;
+  if (sp_io_file_reader_from_path(&reader, path)) return sp_zero_s(sp_str_t);
+
+  u64 num_read = 0;
+  sp_io_read_all(&reader.base, buf, len, &num_read);
+  sp_io_file_reader_close(&reader);
+  return sp_str_trim(sp_str(buf, sp_cast(u32, num_read)));
 }
 
 static sp_msvc_err_t sp_msvc_find_sdks(sp_msvc_t* msvc, sp_msvc_arch_t arch) {
-  c8 buf [SP_PATH_MAX] = sp_zero;
-  DWORD len = sizeof(buf);
+  sp_msvc_path_t root = sp_zero;
+  DWORD len = sizeof(root.data);
   LSTATUS rc = RegGetValueA(
     HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots", "KitsRoot10",
-    RRF_RT_REG_SZ | RRF_SUBKEY_WOW6432KEY, SP_NULLPTR, buf, &len
+    RRF_RT_REG_SZ | RRF_SUBKEY_WOW6432KEY, SP_NULLPTR, root.data, &len
   );
   if (rc == ERROR_FILE_NOT_FOUND) return SP_MSVC_ERR_SDK_NOT_FOUND;
   if (rc != ERROR_SUCCESS) return SP_MSVC_ERR_REGISTRY;
 
-  sp_mem_arena_marker_t scratch = sp_mem_begin_scratch_for(msvc->mem);
-  sp_str_t root = sp_fs_normalize_path(scratch.mem, sp_cstr_as_str(buf));
+  root.len = sp_cstr_len_n(root.data, SP_MSVC_PATH_MAX);
+  sp_msvc_path_normalize(&root);
 
-  sp_da(sp_fs_entry_t) entries = sp_zero;
-  sp_fs_collect(scratch.mem, sp_fs_join_path(scratch.mem, root, sp_str_lit("Lib")), &entries);
+  c8 buf [SP_PATH_MAX] = sp_zero;
+  sp_str_t lib = sp_fmt_buf(buf, sizeof(buf), "{}/Lib", sp_fmt_str(sp_msvc_path_str(&root))).value;
 
-  sp_da_for(entries, it) {
-    sp_fs_entry_t* entry = &entries[it];
-    if (entry->kind != SP_FS_KIND_DIR) continue;
-    if (!sp_str_starts_with(entry->name, sp_str_lit("10."))) continue;
-
-    sp_msvc_sdk_t sdk = sp_msvc_sdk_new(msvc->mem, arch, root, entry->name);
-    if (!sp_fs_is_dir(sdk.lib_ucrt)) continue;
-
-    sp_da_push(msvc->sdks, sdk);
+  SP_ALIGNED u8 dir_buf [SP_SYS_DIR_MIN_BUF];
+  sp_fs_dir_t dir = sp_zero;
+  if (sp_fs_dir_open(&dir, sp_sys_get_root(0), lib, sp_mem_slice(dir_buf, sizeof(dir_buf)))) {
+    return SP_MSVC_ERR_SDK_NOT_FOUND;
   }
-  sp_mem_end_scratch(scratch);
 
-  if (sp_da_empty(msvc->sdks)) return SP_MSVC_ERR_SDK_NOT_FOUND;
-  sp_da_sort(msvc->sdks, sp_msvc_sdk_order);
+  while (true) {
+    sp_fs_dir_entry_t entry = sp_zero;
+    if (sp_fs_dir_next(&dir, &entry)) break;
+    if (!entry.name.data) break;
+    if (entry.kind != SP_FS_KIND_DIR) continue;
+    if (!sp_str_starts_with(entry.name, sp_str_lit("10."))) continue;
+
+    sp_msvc_sdk_t sdk = sp_msvc_sdk_new(arch, sp_msvc_path_str(&root), entry.name);
+    sp_str_r lib_ucrt = sp_msvc_sdk_path_buf(buf, sizeof(buf), &sdk, SP_MSVC_SDK_PATH_LIB_UCRT);
+    if (lib_ucrt.err || !sp_fs_is_dir(lib_ucrt.value)) continue;
+
+    sp_msvc_add_sdk(msvc, &sdk);
+  }
+  sp_fs_dir_close(&dir);
+
+  if (!msvc->num_sdks) return SP_MSVC_ERR_SDK_NOT_FOUND;
   return SP_MSVC_OK;
 }
 
@@ -276,62 +491,83 @@ static sp_msvc_err_t sp_msvc_find_installations(sp_msvc_t* msvc, sp_msvc_arch_t 
 
   sp_msvc_arch_t host = sp_msvc_host_arch();
 
-  sp_mem_arena_marker_t scratch = sp_mem_begin_scratch_for(msvc->mem);
-
-  sp_da(sp_fs_entry_t) entries = sp_zero;
-  sp_fs_collect(
-    scratch.mem,
-    sp_fs_join_path(scratch.mem, program_data, sp_str_lit("Microsoft/VisualStudio/Packages/_Instances")),
-    &entries
+  c8 instances_buf [SP_PATH_MAX] = sp_zero;
+  sp_str_r instances = sp_fmt_buf(
+    instances_buf, sizeof(instances_buf),
+    "{}/Microsoft/VisualStudio/Packages/_Instances", sp_fmt_str(program_data)
   );
+  if (instances.err) return SP_MSVC_ERR_VS_NOT_FOUND;
 
-  sp_da_for(entries, it) {
-    sp_fs_entry_t* entry = &entries[it];
-    if (entry->kind != SP_FS_KIND_DIR) continue;
+  SP_ALIGNED u8 dir_buf [SP_SYS_DIR_MIN_BUF];
+  sp_fs_dir_t dir = sp_zero;
+  if (sp_fs_dir_open(&dir, sp_sys_get_root(0), instances.value, sp_mem_slice(dir_buf, sizeof(dir_buf)))) {
+    return SP_MSVC_ERR_VS_NOT_FOUND;
+  }
 
-    sp_str_t json = sp_zero;
-    sp_io_read_file(scratch.mem, sp_fs_join_path(scratch.mem, entry->path, sp_str_lit("state.json")), &json);
+  while (true) {
+    sp_fs_dir_entry_t entry = sp_zero;
+    if (sp_fs_dir_next(&dir, &entry)) break;
+    if (!entry.name.data) break;
+    if (entry.kind != SP_FS_KIND_DIR) continue;
+
+    c8 buf [SP_PATH_MAX] = sp_zero;
+    sp_str_r path = sp_fmt_buf(buf, sizeof(buf), "{}/{}/state.json", sp_fmt_str(instances.value), sp_fmt_str(entry.name));
+    if (path.err) continue;
 
     sp_msvc_state_t state = sp_zero;
-    if (!sp_msvc_parse_state(scratch.mem, json, &state)) continue;
+    if (!sp_msvc_read_state(path.value, &state)) continue;
 
-    sp_str_t tools = sp_zero;
-    sp_io_read_file(
-      scratch.mem,
-      sp_fs_join_path(scratch.mem, state.install_path, sp_str_lit("VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt")),
-      &tools
+    path = sp_fmt_buf(
+      buf, sizeof(buf),
+      "{}/VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt",
+      sp_fmt_str(sp_msvc_path_str(&state.install_path))
     );
-    tools = sp_str_trim(tools);
+    if (path.err) continue;
+
+    c8 tools_buf [64] = sp_zero;
+    sp_str_t tools = sp_msvc_read_tools_version(path.value, tools_buf, sizeof(tools_buf));
     if (sp_str_empty(tools)) continue;
 
-    sp_msvc_vs_t vs = sp_msvc_vs_new(msvc->mem, host, arch, state, tools);
-    if (!sp_fs_exists(sp_fs_join_path(scratch.mem, vs.lib, sp_str_lit("vcruntime.lib")))) continue;
+    sp_msvc_vs_t vs = sp_msvc_vs_new(host, arch, &state, tools);
 
-    sp_da_push(msvc->installations, vs);
+    sp_io_mem_writer_t io = sp_zero;
+    sp_io_mem_writer_from_buffer(&io, buf, sizeof(buf));
+    if (sp_msvc_vs_path_w(&io.base, &vs, SP_MSVC_VS_PATH_LIB)) continue;
+    if (sp_io_write_str(&io.base, sp_str_lit("/vcruntime.lib"), SP_NULLPTR)) continue;
+    if (!sp_fs_exists(sp_io_mem_writer_as_str(&io))) continue;
+
+    sp_msvc_add_vs(msvc, &vs);
   }
-  sp_mem_end_scratch(scratch);
+  sp_fs_dir_close(&dir);
 
-  if (sp_da_empty(msvc->installations)) return SP_MSVC_ERR_VS_NOT_FOUND;
-  sp_da_sort(msvc->installations, sp_msvc_vs_order);
+  if (!msvc->num_installations) return SP_MSVC_ERR_VS_NOT_FOUND;
   return SP_MSVC_OK;
 }
 
-sp_msvc_err_t sp_msvc_find(sp_mem_t mem, sp_msvc_arch_t arch, sp_msvc_t* out) {
+sp_msvc_err_t sp_msvc_find_ex(sp_msvc_arch_t target, sp_msvc_t* out) {
   *out = sp_zero_s(sp_msvc_t);
-  out->arena = sp_mem_arena_new(mem);
-  out->mem = sp_mem_arena_as_allocator(out->arena);
-  sp_da_init(out->mem, out->sdks);
-  sp_da_init(out->mem, out->installations);
 
-  sp_msvc_err_t sdk_err = sp_msvc_find_sdks(out, arch);
-  sp_msvc_err_t vs_err = sp_msvc_find_installations(out, arch);
+  sp_msvc_err_t sdk_err = sp_msvc_find_sdks(out, target);
+  sp_msvc_err_t vs_err = sp_msvc_find_installations(out, target);
 
   if (vs_err) return vs_err;
   return sdk_err;
 }
 
-void sp_msvc_free(sp_msvc_t* msvc) {
-  sp_mem_arena_destroy(msvc->arena);
+sp_msvc_err_t sp_msvc_find(sp_msvc_t* out) {
+  return sp_msvc_find_ex(sp_msvc_host_arch(), out);
+}
+
+#else
+
+sp_msvc_err_t sp_msvc_find_ex(sp_msvc_arch_t target, sp_msvc_t* out) {
+  (void)target;
+  *out = sp_zero_s(sp_msvc_t);
+  return SP_MSVC_ERR_UNSUPPORTED;
+}
+
+sp_msvc_err_t sp_msvc_find(sp_msvc_t* out) {
+  return sp_msvc_find_ex(SP_MSVC_ARCH_X64, out);
 }
 
 #endif // SP_WIN32

--- a/sp/sp_msvc.h
+++ b/sp/sp_msvc.h
@@ -3,10 +3,6 @@
 
 #include "sp.h"
 
-#if !defined(SP_WIN32)
-#error "msvc.h is Windows only"
-#endif
-
 typedef enum {
   SP_MSVC_ARCH_X64,
   SP_MSVC_ARCH_ARM64,
@@ -38,6 +34,12 @@ typedef struct {
 } sp_msvc_sdk_t;
 
 typedef struct {
+  sp_str_t install_path;
+  sp_str_t build_version;
+  sp_str_t product_line;
+} sp_msvc_state_t;
+
+typedef struct {
   struct {
     sp_str_t product;
     sp_msvc_version_t build;
@@ -56,22 +58,25 @@ typedef struct {
   sp_da(sp_msvc_vs_t) installations;
 } sp_msvc_t;
 
+SP_API sp_msvc_version_t sp_msvc_parse_version(sp_mem_t mem, sp_str_t str);
+SP_API bool              sp_msvc_version_gt(sp_msvc_version_t a, sp_msvc_version_t b);
+SP_API bool              sp_msvc_parse_state(sp_mem_t mem, sp_str_t json, sp_msvc_state_t* out);
+SP_API sp_msvc_sdk_t     sp_msvc_sdk_new(sp_mem_t mem, sp_msvc_arch_t arch, sp_str_t root, sp_str_t version);
+SP_API sp_msvc_vs_t      sp_msvc_vs_new(sp_mem_t mem, sp_msvc_arch_t arch, sp_msvc_state_t state, sp_str_t tools_version);
+
+#if defined(SP_WIN32)
 SP_API sp_msvc_err_t sp_msvc_find(sp_mem_t mem, sp_msvc_arch_t arch, sp_msvc_t* out);
 SP_API void          sp_msvc_free(sp_msvc_t* msvc);
+#endif
 #endif // SP_MSVC_H
 
+#if defined(SP_IMPLEMENTATION) && !defined(SP_MSVC_IMPLEMENTATION)
+  #define SP_MSVC_IMPLEMENTATION
+#endif
+
 #if defined(SP_MSVC_IMPLEMENTATION)
-#include <windows.h>
 
-SP_PRIVATE sp_msvc_err_t      sp_msvc_find_sdks(sp_msvc_t* msvc, sp_msvc_arch_t arch);
-SP_PRIVATE sp_msvc_err_t      sp_msvc_find_installations(sp_msvc_t* msvc, sp_msvc_arch_t arch);
-SP_PRIVATE sp_str_t           sp_msvc_arch_str(sp_msvc_arch_t arch);
-SP_PRIVATE sp_str_t           sp_msvc_bin_subdir(sp_msvc_arch_t arch);
-SP_PRIVATE sp_msvc_version_t  sp_msvc_parse_version(sp_mem_t mem, sp_str_t str);
-SP_PRIVATE bool               sp_msvc_version_gt(sp_msvc_version_t a, sp_msvc_version_t b);
-SP_PRIVATE sp_str_t           sp_msvc_json_get_str(sp_mem_t mem, sp_str_t json, sp_str_t key);
-
-sp_str_t sp_msvc_arch_str(sp_msvc_arch_t arch) {
+static sp_str_t sp_msvc_arch_name(sp_msvc_arch_t arch) {
   switch (arch) {
     case SP_MSVC_ARCH_X64:   { return sp_str_lit("x64"); }
     case SP_MSVC_ARCH_ARM64: { return sp_str_lit("arm64"); }
@@ -79,39 +84,45 @@ sp_str_t sp_msvc_arch_str(sp_msvc_arch_t arch) {
   SP_UNREACHABLE_RETURN(sp_str_lit("x64"));
 }
 
-sp_str_t sp_msvc_bin_subdir(sp_msvc_arch_t arch) {
-  switch (arch) {
-    case SP_MSVC_ARCH_X64:   { return sp_str_lit("Hostx64/x64"); }
-    case SP_MSVC_ARCH_ARM64: { return sp_str_lit("Hostx64/arm64"); }
+static sp_str_t sp_msvc_json_get_str(sp_mem_t mem, sp_str_t json, sp_str_t key) {
+  sp_mem_arena_marker_t scratch = sp_mem_begin_scratch_for(mem);
+  sp_str_t needle = sp_fmt(scratch.mem, "\"{}\":\"", sp_fmt_str(key)).value;
+  s32 pos = sp_str_find(json, needle);
+  u32 start = (u32)pos + needle.len;
+  sp_mem_end_scratch(scratch);
+  if (pos == SP_STR_NO_MATCH) return sp_zero_s(sp_str_t);
+
+  sp_io_dyn_mem_writer_t value = sp_zero;
+  sp_io_dyn_mem_writer_init(mem, &value);
+  sp_for_range(it, start, json.len) {
+    c8 c = json.data[it];
+    if (c == '"') break;
+    if (c == '\\' && it + 1 < json.len) {
+      it++;
+      c = json.data[it];
+    }
+    sp_io_write_c8(&value.base, c);
   }
-  SP_UNREACHABLE_RETURN(sp_str_lit("Hostx64/x64"));
+  return sp_io_dyn_mem_writer_as_str(&value);
 }
 
 sp_msvc_version_t sp_msvc_parse_version(sp_mem_t mem, sp_str_t str) {
-  sp_msvc_version_t v = sp_zero;
-  v.str = sp_str_copy(mem, str);
-
-  u32 parts[4] = sp_zero;
-  u32 part = 0;
-  u32 accum = 0;
-
-  sp_for(i, str.len) {
-    c8 c = str.data[i];
-    if (c == '.') {
-      if (part < 4) parts[part] = accum;
-      part++;
-      accum = 0;
-    } else if (c >= '0' && c <= '9') {
-      accum = accum * 10 + (u32)(c - '0');
-    }
+  sp_mem_arena_marker_t scratch = sp_mem_begin_scratch_for(mem);
+  u32 parts [4] = sp_zero;
+  sp_da(sp_str_t) split = sp_str_split_c8(scratch.mem, str, '.');
+  sp_da_for(split, it) {
+    if (it >= sp_carr_len(parts)) break;
+    parts[it] = sp_parse_u32(split[it]);
   }
-  if (part < 4) parts[part] = accum;
+  sp_mem_end_scratch(scratch);
 
-  v.major    = parts[0];
-  v.minor    = parts[1];
-  v.build    = parts[2];
-  v.revision = parts[3];
-  return v;
+  return (sp_msvc_version_t) {
+    .str      = sp_str_copy(mem, str),
+    .major    = parts[0],
+    .minor    = parts[1],
+    .build    = parts[2],
+    .revision = parts[3],
+  };
 }
 
 bool sp_msvc_version_gt(sp_msvc_version_t a, sp_msvc_version_t b) {
@@ -121,191 +132,143 @@ bool sp_msvc_version_gt(sp_msvc_version_t a, sp_msvc_version_t b) {
   return a.revision > b.revision;
 }
 
-sp_str_t sp_msvc_json_get_str(sp_mem_t mem, sp_str_t json, sp_str_t key) {
-  sp_mem_arena_marker_t scratch = sp_mem_begin_scratch_for(mem);
-  sp_str_t needle = sp_fmt(scratch.mem, "\"{}\":\"", sp_fmt_str(key)).value;
+bool sp_msvc_parse_state(sp_mem_t mem, sp_str_t json, sp_msvc_state_t* out) {
+  *out = sp_zero_s(sp_msvc_state_t);
 
-  s32 pos = sp_str_find(json, needle);
-  if (pos == SP_STR_NO_MATCH) {
-    sp_mem_end_scratch(scratch);
-    return sp_zero_s(sp_str_t);
-  }
+  sp_str_t install = sp_msvc_json_get_str(mem, json, sp_str_lit("installationPath"));
+  sp_str_t build = sp_msvc_json_get_str(mem, json, sp_str_lit("buildVersion"));
+  if (sp_str_empty(install) || sp_str_empty(build)) return false;
 
-  u32 value_start = (u32)pos + needle.len;
-  u32 value_end = value_start;
-  while (value_end < json.len && json.data[value_end] != '"') {
-    if (json.data[value_end] == '\\' && value_end + 1 < json.len) {
-      value_end++;
-    }
-    value_end++;
-  }
-
-  sp_str_t raw = sp_str_sub(json, (s32)value_start, (s32)(value_end - value_start));
-
-  sp_io_dyn_mem_writer_t builder = sp_zero;
-  sp_io_dyn_mem_writer_init(mem, &builder);
-  sp_for(i, raw.len) {
-    if (raw.data[i] == '\\' && i + 1 < raw.len && raw.data[i + 1] == '\\') {
-      sp_io_write_c8(&builder.base, '\\');
-      i++;
-    } else {
-      sp_io_write_c8(&builder.base, raw.data[i]);
-    }
-  }
-
-  sp_str_t result = sp_io_dyn_mem_writer_as_str(&builder);
-
-  sp_mem_end_scratch(scratch);
-  return result;
+  out->install_path = sp_fs_normalize_path(mem, install);
+  out->build_version = build;
+  out->product_line = sp_msvc_json_get_str(mem, json, sp_str_lit("productLineVersion"));
+  return true;
 }
 
-sp_msvc_err_t sp_msvc_find_sdks(sp_msvc_t* msvc, sp_msvc_arch_t arch) {
-  sp_mem_t mem = msvc->mem;
-  sp_da(sp_msvc_sdk_t)* out = &msvc->sdks;
-  HKEY roots_key;
-  LSTATUS rc = RegOpenKeyExA(
-    HKEY_LOCAL_MACHINE,
-    "SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots",
-    0, KEY_QUERY_VALUE | KEY_WOW64_32KEY | KEY_ENUMERATE_SUB_KEYS,
-    &roots_key
+sp_msvc_sdk_t sp_msvc_sdk_new(sp_mem_t mem, sp_msvc_arch_t arch, sp_str_t root, sp_str_t version) {
+  sp_str_t arch_name = sp_msvc_arch_name(arch);
+
+  return (sp_msvc_sdk_t) {
+    .version        = sp_msvc_parse_version(mem, version),
+    .root           = sp_str_copy(mem, root),
+    .lib_um         = sp_fmt(mem, "{}/Lib/{}/um/{}", sp_fmt_str(root), sp_fmt_str(version), sp_fmt_str(arch_name)).value,
+    .lib_ucrt       = sp_fmt(mem, "{}/Lib/{}/ucrt/{}", sp_fmt_str(root), sp_fmt_str(version), sp_fmt_str(arch_name)).value,
+    .include_ucrt   = sp_fmt(mem, "{}/Include/{}/ucrt", sp_fmt_str(root), sp_fmt_str(version)).value,
+    .include_um     = sp_fmt(mem, "{}/Include/{}/um", sp_fmt_str(root), sp_fmt_str(version)).value,
+    .include_shared = sp_fmt(mem, "{}/Include/{}/shared", sp_fmt_str(root), sp_fmt_str(version)).value,
+  };
+}
+
+sp_msvc_vs_t sp_msvc_vs_new(sp_mem_t mem, sp_msvc_arch_t arch, sp_msvc_state_t state, sp_str_t tools_version) {
+  sp_str_t arch_name = sp_msvc_arch_name(arch);
+  sp_str_t tools = sp_fmt(mem, "{}/VC/Tools/MSVC/{}", sp_fmt_str(state.install_path), sp_fmt_str(tools_version)).value;
+
+  return (sp_msvc_vs_t) {
+    .version = {
+      .product = sp_str_copy(mem, state.product_line),
+      .build   = sp_msvc_parse_version(mem, state.build_version),
+      .tools   = sp_msvc_parse_version(mem, tools_version),
+    },
+    .install_path = sp_str_copy(mem, state.install_path),
+    .lib          = sp_fmt(mem, "{}/Lib/{}", sp_fmt_str(tools), sp_fmt_str(arch_name)).value,
+    .include      = sp_fmt(mem, "{}/include", sp_fmt_str(tools)).value,
+    .bin          = sp_fmt(mem, "{}/bin/Hostx64/{}", sp_fmt_str(tools), sp_fmt_str(arch_name)).value,
+  };
+}
+
+#if defined(SP_WIN32)
+#include <windows.h>
+
+static s32 sp_msvc_sdk_order(const void* a, const void* b) {
+  const sp_msvc_sdk_t* sa = (const sp_msvc_sdk_t*)a;
+  const sp_msvc_sdk_t* sb = (const sp_msvc_sdk_t*)b;
+  if (sp_msvc_version_gt(sa->version, sb->version)) return -1;
+  if (sp_msvc_version_gt(sb->version, sa->version)) return 1;
+  return 0;
+}
+
+static s32 sp_msvc_vs_order(const void* a, const void* b) {
+  const sp_msvc_vs_t* va = (const sp_msvc_vs_t*)a;
+  const sp_msvc_vs_t* vb = (const sp_msvc_vs_t*)b;
+  if (sp_msvc_version_gt(va->version.build, vb->version.build)) return -1;
+  if (sp_msvc_version_gt(vb->version.build, va->version.build)) return 1;
+  return 0;
+}
+
+static sp_msvc_err_t sp_msvc_find_sdks(sp_msvc_t* msvc, sp_msvc_arch_t arch) {
+  c8 buf [SP_PATH_MAX] = sp_zero;
+  DWORD len = sizeof(buf);
+  LSTATUS rc = RegGetValueA(
+    HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots", "KitsRoot10",
+    RRF_RT_REG_SZ | RRF_SUBKEY_WOW6432KEY, SP_NULLPTR, buf, &len
   );
+  if (rc == ERROR_FILE_NOT_FOUND) return SP_MSVC_ERR_SDK_NOT_FOUND;
   if (rc != ERROR_SUCCESS) return SP_MSVC_ERR_REGISTRY;
 
-  c8 root_buf[SP_PATH_MAX] = sp_zero;
-  DWORD root_len = SP_PATH_MAX;
-  DWORD type;
-  rc = RegQueryValueExA(roots_key, "KitsRoot10", SP_NULLPTR, &type, (LPBYTE)root_buf, &root_len);
-  RegCloseKey(roots_key);
+  sp_mem_arena_marker_t scratch = sp_mem_begin_scratch_for(msvc->mem);
+  sp_str_t root = sp_fs_normalize_path(scratch.mem, sp_cstr_as_str(buf));
 
-  if (rc != ERROR_SUCCESS || type != REG_SZ) return SP_MSVC_ERR_SDK_NOT_FOUND;
+  sp_da(sp_fs_entry_t) entries = sp_zero;
+  sp_fs_collect(scratch.mem, sp_fs_join_path(scratch.mem, root, sp_str_lit("Lib")), &entries);
 
-  sp_str_t sdk_root = sp_fs_normalize_path(mem, sp_str_view(root_buf));
-  sp_str_t lib_dir = sp_fs_join_path(mem, sdk_root, sp_str_lit("Lib"));
-  sp_str_t arch_str = sp_msvc_arch_str(arch);
+  sp_da_for(entries, it) {
+    sp_fs_entry_t* entry = &entries[it];
+    if (entry->kind != SP_FS_KIND_DIR) continue;
+    if (!sp_str_starts_with(entry->name, sp_str_lit("10."))) continue;
 
-  for (sp_fs_it_t it = sp_fs_it_new(mem, lib_dir); sp_fs_it_valid(&it); sp_fs_it_next(&it)) {
-    if (it.entry.kind != SP_FS_KIND_DIR) continue;
-    sp_str_t name = it.entry.name;
-    if (!sp_str_starts_with(name, sp_str_lit("10."))) continue;
+    sp_msvc_sdk_t sdk = sp_msvc_sdk_new(msvc->mem, arch, root, entry->name);
+    if (!sp_fs_is_dir(sdk.lib_ucrt)) continue;
 
-    sp_str_t ucrt_lib = sp_fs_join_path(mem,
-      sp_fs_join_path(mem, it.entry.path, sp_str_lit("ucrt")), arch_str
-    );
-    if (!sp_fs_is_dir(ucrt_lib)) continue;
-
-    sp_str_t ver_root = it.entry.path;
-    sp_msvc_sdk_t sdk = {
-      .version     = sp_msvc_parse_version(mem, name),
-      .root        = sp_str_copy(mem, sdk_root),
-      .lib_um      = sp_fs_join_path(mem, sp_fs_join_path(mem, ver_root, sp_str_lit("um")), arch_str),
-      .lib_ucrt    = sp_str_copy(mem, ucrt_lib),
-      .include_ucrt   = sp_fs_join_path(mem,
-        sp_fs_join_path(mem, sp_fs_join_path(mem, sdk_root, sp_str_lit("Include")), name), sp_str_lit("ucrt")
-      ),
-      .include_um     = sp_fs_join_path(mem,
-        sp_fs_join_path(mem, sp_fs_join_path(mem, sdk_root, sp_str_lit("Include")), name), sp_str_lit("um")
-      ),
-      .include_shared = sp_fs_join_path(mem,
-        sp_fs_join_path(mem, sp_fs_join_path(mem, sdk_root, sp_str_lit("Include")), name), sp_str_lit("shared")
-      ),
-    };
-    sp_da_push(*out, sdk);
+    sp_da_push(msvc->sdks, sdk);
   }
+  sp_mem_end_scratch(scratch);
 
-  sp_da_for(*out, i) {
-    sp_for_range(j, i + 1, sp_da_size(*out)) {
-      if (sp_msvc_version_gt((*out)[j].version, (*out)[i].version)) {
-        sp_msvc_sdk_t tmp = (*out)[i];
-        (*out)[i] = (*out)[j];
-        (*out)[j] = tmp;
-      }
-    }
-  }
-
-  if (sp_da_empty(*out)) return SP_MSVC_ERR_SDK_NOT_FOUND;
+  if (sp_da_empty(msvc->sdks)) return SP_MSVC_ERR_SDK_NOT_FOUND;
+  sp_da_sort(msvc->sdks, sp_msvc_sdk_order);
   return SP_MSVC_OK;
 }
 
-sp_msvc_err_t sp_msvc_find_installations(sp_msvc_t* msvc, sp_msvc_arch_t arch) {
-  sp_mem_t mem = msvc->mem;
-  sp_da(sp_msvc_vs_t)* out = &msvc->installations;
+static sp_msvc_err_t sp_msvc_find_installations(sp_msvc_t* msvc, sp_msvc_arch_t arch) {
   sp_str_t program_data = sp_os_env_get(sp_str_lit("ProgramData"));
   if (!sp_str_valid(program_data)) return SP_MSVC_ERR_VS_NOT_FOUND;
 
-  sp_str_t instances_dir = sp_fs_join_path(mem,
-    program_data, sp_str_lit("Microsoft/VisualStudio/Packages/_Instances")
+  sp_mem_arena_marker_t scratch = sp_mem_begin_scratch_for(msvc->mem);
+
+  sp_da(sp_fs_entry_t) entries = sp_zero;
+  sp_fs_collect(
+    scratch.mem,
+    sp_fs_join_path(scratch.mem, program_data, sp_str_lit("Microsoft/VisualStudio/Packages/_Instances")),
+    &entries
   );
-  if (!sp_fs_is_dir(instances_dir)) return SP_MSVC_ERR_VS_NOT_FOUND;
 
-  sp_str_t arch_str = sp_msvc_arch_str(arch);
-
-  for (sp_fs_it_t it = sp_fs_it_new(mem, instances_dir); sp_fs_it_valid(&it); sp_fs_it_next(&it)) {
-    if (it.entry.kind != SP_FS_KIND_DIR) continue;
-
-    sp_str_t state_path = sp_fs_join_path(mem, it.entry.path, sp_str_lit("state.json"));
-    if (!sp_fs_exists(state_path)) continue;
+  sp_da_for(entries, it) {
+    sp_fs_entry_t* entry = &entries[it];
+    if (entry->kind != SP_FS_KIND_DIR) continue;
 
     sp_str_t json = sp_zero;
-    sp_io_read_file(mem, state_path, &json);
-    if (sp_str_empty(json)) continue;
+    sp_io_read_file(scratch.mem, sp_fs_join_path(scratch.mem, entry->path, sp_str_lit("state.json")), &json);
 
-    sp_str_t install_path = sp_msvc_json_get_str(mem, json, sp_str_lit("installationPath"));
-    if (sp_str_empty(install_path)) continue;
+    sp_msvc_state_t state = sp_zero;
+    if (!sp_msvc_parse_state(scratch.mem, json, &state)) continue;
 
-    install_path = sp_fs_normalize_path(mem, install_path);
-
-    sp_str_t build_version_str = sp_msvc_json_get_str(mem, json, sp_str_lit("buildVersion"));
-    if (sp_str_empty(build_version_str)) continue;
-
-    sp_str_t product_line = sp_msvc_json_get_str(mem, json, sp_str_lit("productLineVersion"));
-
-    sp_str_t tools_file = sp_fs_join_path(mem,
-      install_path, sp_str_lit("VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt")
+    sp_str_t tools = sp_zero;
+    sp_io_read_file(
+      scratch.mem,
+      sp_fs_join_path(scratch.mem, state.install_path, sp_str_lit("VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt")),
+      &tools
     );
-    sp_str_t tools_version_str = sp_zero;
-    sp_io_read_file(mem, tools_file, &tools_version_str);
-    if (sp_str_empty(tools_version_str)) continue;
+    tools = sp_str_trim(tools);
+    if (sp_str_empty(tools)) continue;
 
-    tools_version_str = sp_str_trim(tools_version_str);
+    sp_msvc_vs_t vs = sp_msvc_vs_new(msvc->mem, arch, state, tools);
+    if (!sp_fs_exists(sp_fs_join_path(scratch.mem, vs.lib, sp_str_lit("vcruntime.lib")))) continue;
 
-    sp_str_t tools_base = sp_fs_join_path(mem,
-      sp_fs_join_path(mem, install_path, sp_str_lit("VC/Tools/MSVC")), tools_version_str
-    );
-
-    sp_str_t lib_dir = sp_fs_join_path(mem,
-      sp_fs_join_path(mem, tools_base, sp_str_lit("Lib")), arch_str
-    );
-
-    sp_str_t vcruntime = sp_fs_join_path(mem, lib_dir, sp_str_lit("vcruntime.lib"));
-    if (!sp_fs_exists(vcruntime)) continue;
-
-    sp_msvc_vs_t vs = {
-      .version = {
-        .product = sp_str_copy(mem, product_line),
-        .build   = sp_msvc_parse_version(mem, build_version_str),
-        .tools   = sp_msvc_parse_version(mem, tools_version_str),
-      },
-      .install_path = sp_str_copy(mem, install_path),
-      .lib          = sp_str_copy(mem, lib_dir),
-      .include      = sp_fs_join_path(mem, tools_base, sp_str_lit("include")),
-      .bin          = sp_fs_join_path(mem,
-        sp_fs_join_path(mem, tools_base, sp_str_lit("bin")), sp_msvc_bin_subdir(arch)
-      ),
-    };
-    sp_da_push(*out, vs);
+    sp_da_push(msvc->installations, vs);
   }
+  sp_mem_end_scratch(scratch);
 
-  sp_da_for(*out, i) {
-    sp_for_range(j, i + 1, sp_da_size(*out)) {
-      if (sp_msvc_version_gt((*out)[j].version.build, (*out)[i].version.build)) {
-        sp_msvc_vs_t tmp = (*out)[i];
-        (*out)[i] = (*out)[j];
-        (*out)[j] = tmp;
-      }
-    }
-  }
-
-  if (sp_da_empty(*out)) return SP_MSVC_ERR_VS_NOT_FOUND;
+  if (sp_da_empty(msvc->installations)) return SP_MSVC_ERR_VS_NOT_FOUND;
+  sp_da_sort(msvc->installations, sp_msvc_vs_order);
   return SP_MSVC_OK;
 }
 
@@ -320,13 +283,12 @@ sp_msvc_err_t sp_msvc_find(sp_mem_t mem, sp_msvc_arch_t arch, sp_msvc_t* out) {
   sp_msvc_err_t vs_err = sp_msvc_find_installations(out, arch);
 
   if (vs_err) return vs_err;
-  if (sdk_err) return sdk_err;
-  return SP_MSVC_OK;
+  return sdk_err;
 }
 
 void sp_msvc_free(sp_msvc_t* msvc) {
-  if (!msvc) return;
   sp_mem_arena_destroy(msvc->arena);
 }
 
+#endif // SP_WIN32
 #endif // SP_MSVC_IMPLEMENTATION

--- a/spn.toml
+++ b/spn.toml
@@ -24,6 +24,7 @@ source = [
   "test/sys/inherit.c",
   "test/fs/iter/os.c", "test/fs/iter/iter.c", "test/fs/wtf8/*.c",
   "test/fs/*.c", "test/fs/windows/nt_path.c",
+  "test/msvc/*.c",
   "test/mem/uninitialized.c",
   "test/atomic.c",
   "test/sync/*.c", "test/sync/os/*.c"
@@ -53,6 +54,10 @@ source = ["test/main.c", "test/atomic.c"]
 [[test]]
 name = "fs"
 source = ["test/main.c", "test/fs/iter/iter.c", "test/fs/iter/os.c", "test/fs/wtf8/*.c", "test/fs/*.c", "test/fs/windows/nt_path.c"]
+
+[[test]]
+name = "msvc"
+source = ["test/main.c", "test/msvc/*.c"]
 
 [[test]]
 name = "sync"

--- a/spn.toml
+++ b/spn.toml
@@ -56,7 +56,7 @@ name = "fs"
 source = ["test/main.c", "test/fs/iter/iter.c", "test/fs/iter/os.c", "test/fs/wtf8/*.c", "test/fs/*.c", "test/fs/windows/nt_path.c"]
 
 [[test]]
-name = "msvc"
+name = "msvct"
 source = ["test/main.c", "test/msvc/*.c"]
 
 [[test]]
@@ -91,9 +91,13 @@ macos = { frameworks = ["Security", "CoreFoundation"] }
 [deps.test]
 mbedtls = "3.6.6"
 
-[[bin]]
+[[example]]
 name = "zero_copy"
 source = ["example/zero_copy.c"]
+
+[[example]]
+name = "msvc"
+source = ["example/msvc.c"]
 
 [profile.sanitizer]
 linkage = "shared"

--- a/test/msvc/find.c
+++ b/test/msvc/find.c
@@ -29,7 +29,7 @@ sp_test(msvc, find) {
 
     sp_io_mem_writer_t io = sp_zero;
     sp_io_mem_writer_from_buffer(&io, buf, sizeof(buf));
-    sp_must_eq(t, sp_msvc_vs_path_w(&io.base, vs, SP_MSVC_VS_PATH_LIB), SP_OK);
+    sp_must_eq(t, sp_msvc_vs_path_io(&io.base, vs, SP_MSVC_VS_PATH_LIB), SP_OK);
     sp_must_eq(t, sp_io_write_str(&io.base, sp_str_lit("/vcruntime.lib"), SP_NULLPTR), SP_OK);
     sp_expect(t, sp_fs_exists(sp_io_mem_writer_as_str(&io)));
     if (it) sp_expect(t, !sp_msvc_version_gt(vs->version.build, msvc.installations[it - 1].version.build));

--- a/test/msvc/find.c
+++ b/test/msvc/find.c
@@ -1,0 +1,38 @@
+#define SP_MSVC_IMPLEMENTATION
+#include "msvc.h"
+
+#if defined(SP_WIN32)
+
+sp_test(msvc, find) {
+  sp_msvc_t msvc = sp_zero;
+  sp_msvc_err_t err = sp_msvc_find(sp_test_arena(t), SP_MSVC_ARCH_X64, &msvc);
+  if (err) return sp_test_skip(t, "no msvc on this machine");
+
+  sp_must_gt(t, sp_da_size(msvc.sdks), 0);
+  sp_da_for(msvc.sdks, it) {
+    sp_msvc_sdk_t* sdk = &msvc.sdks[it];
+    sp_expect_eq(t, sdk->version.major, 10u);
+    sp_expect(t, sp_fs_is_absolute(sdk->root));
+    sp_expect(t, sp_fs_is_dir(sdk->lib_ucrt));
+    if (it) sp_expect(t, !sp_msvc_version_gt(sdk->version, msvc.sdks[it - 1].version));
+  }
+
+  sp_must_gt(t, sp_da_size(msvc.installations), 0);
+  sp_da_for(msvc.installations, it) {
+    sp_msvc_vs_t* vs = &msvc.installations[it];
+    sp_expect(t, sp_fs_is_absolute(vs->install_path));
+    sp_expect(t, sp_fs_exists(sp_fs_join_path(msvc.mem, vs->lib, sp_str_lit("vcruntime.lib"))));
+    if (it) sp_expect(t, !sp_msvc_version_gt(vs->version.build, msvc.installations[it - 1].version.build));
+  }
+
+  sp_msvc_free(&msvc);
+  return SP_OK;
+}
+
+#else
+
+sp_test(msvc, find_skipped_non_windows) {
+  return sp_test_skip(t, "msvc discovery requires windows");
+}
+
+#endif

--- a/test/msvc/find.c
+++ b/test/msvc/find.c
@@ -5,34 +5,47 @@
 
 sp_test(msvc, find) {
   sp_msvc_t msvc = sp_zero;
-  sp_msvc_err_t err = sp_msvc_find(sp_test_arena(t), SP_MSVC_ARCH_X64, &msvc);
+  sp_msvc_err_t err = sp_msvc_find(&msvc);
   if (err) return sp_test_skip(t, "no msvc on this machine");
 
-  sp_must_gt(t, sp_da_size(msvc.sdks), 0);
-  sp_da_for(msvc.sdks, it) {
+  c8 buf [SP_MSVC_PATH_MAX] = sp_zero;
+
+  sp_must_gt(t, msvc.num_sdks, 0);
+  sp_for(it, msvc.num_sdks) {
     sp_msvc_sdk_t* sdk = &msvc.sdks[it];
     sp_expect_eq(t, sdk->version.major, 10u);
-    sp_expect(t, sp_fs_is_absolute(sdk->root));
-    sp_expect(t, sp_fs_is_dir(sdk->lib_ucrt));
+    sp_expect(t, sp_fs_is_absolute(sp_msvc_path_str(&sdk->root)));
+
+    sp_str_r lib_ucrt = sp_msvc_sdk_path_buf(buf, sizeof(buf), sdk, SP_MSVC_SDK_PATH_LIB_UCRT);
+    sp_must_eq(t, lib_ucrt.err, SP_OK);
+    sp_expect(t, sp_fs_is_dir(lib_ucrt.value));
     if (it) sp_expect(t, !sp_msvc_version_gt(sdk->version, msvc.sdks[it - 1].version));
   }
 
-  sp_must_gt(t, sp_da_size(msvc.installations), 0);
-  sp_da_for(msvc.installations, it) {
+  sp_must_gt(t, msvc.num_installations, 0);
+  sp_for(it, msvc.num_installations) {
     sp_msvc_vs_t* vs = &msvc.installations[it];
-    sp_expect(t, sp_fs_is_absolute(vs->install_path));
-    sp_expect(t, sp_fs_exists(sp_fs_join_path(msvc.mem, vs->lib, sp_str_lit("vcruntime.lib"))));
+    sp_expect(t, sp_fs_is_absolute(sp_msvc_path_str(&vs->install_path)));
+
+    sp_io_mem_writer_t io = sp_zero;
+    sp_io_mem_writer_from_buffer(&io, buf, sizeof(buf));
+    sp_must_eq(t, sp_msvc_vs_path_w(&io.base, vs, SP_MSVC_VS_PATH_LIB), SP_OK);
+    sp_must_eq(t, sp_io_write_str(&io.base, sp_str_lit("/vcruntime.lib"), SP_NULLPTR), SP_OK);
+    sp_expect(t, sp_fs_exists(sp_io_mem_writer_as_str(&io)));
     if (it) sp_expect(t, !sp_msvc_version_gt(vs->version.build, msvc.installations[it - 1].version.build));
   }
 
-  sp_msvc_free(&msvc);
   return SP_OK;
 }
 
 #else
 
-sp_test(msvc, find_skipped_non_windows) {
-  return sp_test_skip(t, "msvc discovery requires windows");
+sp_test(msvc, find_unsupported) {
+  sp_msvc_t msvc = sp_zero;
+  sp_expect_eq(t, sp_msvc_find(&msvc), SP_MSVC_ERR_UNSUPPORTED);
+  sp_expect_eq(t, msvc.num_sdks, 0u);
+  sp_expect_eq(t, msvc.num_installations, 0u);
+  return SP_OK;
 }
 
 #endif

--- a/test/msvc/msvc.h
+++ b/test/msvc/msvc.h
@@ -1,0 +1,7 @@
+#ifndef MSVC_TEST_H
+#define MSVC_TEST_H
+
+#include "sp/sp_msvc.h"
+#include "sp/sp_test.h"
+
+#endif

--- a/test/msvc/msvc.h
+++ b/test/msvc/msvc.h
@@ -1,6 +1,9 @@
 #ifndef MSVC_TEST_H
 #define MSVC_TEST_H
 
+#define SP_PRIVATE
+#define SP_IMP
+#define SP_PRIVATE_HEADER
 #include "sp/sp_msvc.h"
 #include "sp/sp_test.h"
 

--- a/test/msvc/parse_state.c
+++ b/test/msvc/parse_state.c
@@ -1,0 +1,70 @@
+#include "msvc.h"
+
+typedef struct {
+  bool ok;
+  const c8* install_path;
+  const c8* build_version;
+  const c8* product_line;
+} expect_t;
+
+typedef struct {
+  const c8* name;
+  const c8* json;
+  expect_t expect;
+} test_t;
+
+static const test_t tests [] = {
+  {
+    .name = "full",
+    .json = "{\"installationPath\":\"C:\\\\A\\\\B\",\"buildVersion\":\"17.14.3\",\"productLineVersion\":\"2022\"}",
+    .expect = { .ok = true, .install_path = "C:/A/B", .build_version = "17.14.3", .product_line = "2022" },
+  },
+  {
+    .name = "forward_slashes",
+    .json = "{\"installationPath\":\"C:/A\",\"buildVersion\":\"17.0.0\",\"productLineVersion\":\"2022\"}",
+    .expect = { .ok = true, .install_path = "C:/A", .build_version = "17.0.0", .product_line = "2022" },
+  },
+  {
+    .name = "no_product_line",
+    .json = "{\"installationPath\":\"C:\\\\A\",\"buildVersion\":\"17.0.0\"}",
+    .expect = { .ok = true, .install_path = "C:/A", .build_version = "17.0.0", .product_line = "" },
+  },
+  {
+    .name = "escaped_quote",
+    .json = "{\"installationPath\":\"C:\\\\A\\\"B\",\"buildVersion\":\"17.0.0\"}",
+    .expect = { .ok = true, .install_path = "C:/A\"B", .build_version = "17.0.0", .product_line = "" },
+  },
+  {
+    .name = "no_install_path",
+    .json = "{\"buildVersion\":\"17.0.0\"}",
+  },
+  {
+    .name = "no_build_version",
+    .json = "{\"installationPath\":\"C:\\\\A\"}",
+  },
+  {
+    .name = "install_path_not_a_string",
+    .json = "{\"installationPath\":3,\"buildVersion\":\"17.0.0\"}",
+  },
+  {
+    .name = "truncated_value",
+    .json = "{\"installationPath\":\"C:\\\\A\",\"buildVersion\":\"17.0",
+    .expect = { .ok = true, .install_path = "C:/A", .build_version = "17.0", .product_line = "" },
+  },
+  {
+    .name = "empty",
+    .json = "",
+  },
+};
+
+sp_test_each(msvc, parse_state, test_t, tests) {
+  sp_msvc_state_t state = sp_zero;
+  bool ok = sp_msvc_parse_state(sp_test_arena(t), sp_cstr_as_str(it->json), &state);
+  sp_must_eq(t, ok, it->expect.ok);
+  if (!ok) return SP_OK;
+
+  sp_expect_str_eq_c(t, state.install_path, it->expect.install_path);
+  sp_expect_str_eq_c(t, state.build_version, it->expect.build_version);
+  sp_expect_str_eq_c(t, state.product_line, it->expect.product_line);
+  return SP_OK;
+}

--- a/test/msvc/parse_state.c
+++ b/test/msvc/parse_state.c
@@ -62,19 +62,27 @@ static const test_t tests [] = {
     .expect = { .ok = true, .install_path = "C:/A", .build_version = "17.0.0", .product_line = "" },
   },
   {
+    .name = "duplicate_key",
+    .json = "{\"buildVersion\":\"1.0\",\"buildVersion\":\"2.0\",\"installationPath\":\"C:\\\\A\"}",
+    .expect = { .ok = true, .install_path = "C:/A", .build_version = "1.0", .product_line = "" },
+  },
+  {
     .name = "empty",
     .json = "",
   },
 };
 
 sp_test_each(msvc, parse_state, test_t, tests) {
+  sp_io_reader_t reader = sp_zero;
+  sp_io_reader_from_mem(&reader, it->json, sp_cstr_len(it->json));
+
   sp_msvc_state_t state = sp_zero;
-  bool ok = sp_msvc_parse_state(sp_test_arena(t), sp_cstr_as_str(it->json), &state);
+  bool ok = sp_msvc_parse_state(&reader, &state);
   sp_must_eq(t, ok, it->expect.ok);
   if (!ok) return SP_OK;
 
-  sp_expect_str_eq_c(t, state.install_path, it->expect.install_path);
-  sp_expect_str_eq_c(t, state.build_version, it->expect.build_version);
-  sp_expect_str_eq_c(t, state.product_line, it->expect.product_line);
+  sp_expect_str_eq_c(t, sp_msvc_path_str(&state.install_path), it->expect.install_path);
+  sp_expect_str_eq_c(t, sp_msvc_path_str(&state.build_version), it->expect.build_version);
+  sp_expect_str_eq_c(t, sp_msvc_path_str(&state.product_line), it->expect.product_line);
   return SP_OK;
 }

--- a/test/msvc/parse_state.c
+++ b/test/msvc/parse_state.c
@@ -52,6 +52,16 @@ static const test_t tests [] = {
     .expect = { .ok = true, .install_path = "C:/A", .build_version = "17.0", .product_line = "" },
   },
   {
+    .name = "whitespace",
+    .json = "{\n  \"installationPath\" : \"C:\\\\A\",\n  \"buildVersion\":\n\"17.0.0\"\n}",
+    .expect = { .ok = true, .install_path = "C:/A", .build_version = "17.0.0", .product_line = "" },
+  },
+  {
+    .name = "key_in_value",
+    .json = "{\"A\":\"installationPath\",\"installationPath\":\"C:\\\\A\",\"buildVersion\":\"17.0.0\"}",
+    .expect = { .ok = true, .install_path = "C:/A", .build_version = "17.0.0", .product_line = "" },
+  },
+  {
     .name = "empty",
     .json = "",
   },

--- a/test/msvc/parse_version.c
+++ b/test/msvc/parse_version.c
@@ -1,6 +1,7 @@
 #include "msvc.h"
 
 typedef struct {
+  const c8* str;
   u32 major;
   u32 minor;
   u32 build;
@@ -38,11 +39,16 @@ static const test_t tests [] = {
     .str = "10.x.3",
     .expect = { .major = 10, .build = 3 },
   },
+  {
+    .name = "str_truncated",
+    .str = "1.2.3.4.superduperextralongtail",
+    .expect = { .str = "1.2.3.4.superduperextral", .major = 1, .minor = 2, .build = 3, .revision = 4 },
+  },
 };
 
 sp_test_each(msvc, parse_version, test_t, tests) {
-  sp_msvc_version_t version = sp_msvc_parse_version(sp_test_arena(t), sp_cstr_as_str(it->str));
-  sp_expect_str_eq_c(t, version.str, it->str);
+  sp_msvc_version_t version = sp_msvc_parse_version(sp_cstr_as_str(it->str));
+  sp_expect_str_eq_c(t, sp_msvc_version_str(&version), it->expect.str ? it->expect.str : it->str);
   sp_expect_eq(t, version.major, it->expect.major);
   sp_expect_eq(t, version.minor, it->expect.minor);
   sp_expect_eq(t, version.build, it->expect.build);

--- a/test/msvc/parse_version.c
+++ b/test/msvc/parse_version.c
@@ -1,0 +1,51 @@
+#include "msvc.h"
+
+typedef struct {
+  u32 major;
+  u32 minor;
+  u32 build;
+  u32 revision;
+} expect_t;
+
+typedef struct {
+  const c8* name;
+  const c8* str;
+  expect_t expect;
+} test_t;
+
+static const test_t tests [] = {
+  {
+    .name = "full",
+    .str = "10.0.22621.3235",
+    .expect = { .major = 10, .build = 22621, .revision = 3235 },
+  },
+  {
+    .name = "one_part",
+    .str = "17",
+    .expect = { .major = 17 },
+  },
+  {
+    .name = "empty",
+    .str = "",
+  },
+  {
+    .name = "extra_parts",
+    .str = "1.2.3.4.5",
+    .expect = { .major = 1, .minor = 2, .build = 3, .revision = 4 },
+  },
+  {
+    .name = "garbage_part",
+    .str = "10.x.3",
+    .expect = { .major = 10, .build = 3 },
+  },
+};
+
+sp_test_each(msvc, parse_version, test_t, tests) {
+  sp_msvc_version_t version = sp_msvc_parse_version(sp_test_arena(t), sp_cstr_as_str(it->str));
+  sp_expect_str_eq_c(t, version.str, it->str);
+  sp_expect_eq(t, version.major, it->expect.major);
+  sp_expect_eq(t, version.minor, it->expect.minor);
+  sp_expect_eq(t, version.build, it->expect.build);
+  sp_expect_eq(t, version.revision, it->expect.revision);
+  return SP_OK;
+}

--- a/test/msvc/sdk.c
+++ b/test/msvc/sdk.c
@@ -1,0 +1,53 @@
+#include "msvc.h"
+
+typedef struct {
+  const c8* lib_um;
+  const c8* lib_ucrt;
+  const c8* include_ucrt;
+  const c8* include_um;
+  const c8* include_shared;
+} expect_t;
+
+typedef struct {
+  const c8* name;
+  sp_msvc_arch_t arch;
+  expect_t expect;
+} test_t;
+
+static const test_t tests [] = {
+  {
+    .name = "x64",
+    .expect = {
+      .lib_um         = "C:/K/Lib/1.2.3.4/um/x64",
+      .lib_ucrt       = "C:/K/Lib/1.2.3.4/ucrt/x64",
+      .include_ucrt   = "C:/K/Include/1.2.3.4/ucrt",
+      .include_um     = "C:/K/Include/1.2.3.4/um",
+      .include_shared = "C:/K/Include/1.2.3.4/shared",
+    },
+  },
+  {
+    .name = "arm64",
+    .arch = SP_MSVC_ARCH_ARM64,
+    .expect = {
+      .lib_um         = "C:/K/Lib/1.2.3.4/um/arm64",
+      .lib_ucrt       = "C:/K/Lib/1.2.3.4/ucrt/arm64",
+      .include_ucrt   = "C:/K/Include/1.2.3.4/ucrt",
+      .include_um     = "C:/K/Include/1.2.3.4/um",
+      .include_shared = "C:/K/Include/1.2.3.4/shared",
+    },
+  },
+};
+
+sp_test_each(msvc, sdk_new, test_t, tests) {
+  sp_msvc_sdk_t sdk = sp_msvc_sdk_new(
+    sp_test_arena(t), it->arch, sp_str_lit("C:/K"), sp_str_lit("1.2.3.4")
+  );
+  sp_expect_str_eq_c(t, sdk.root, "C:/K");
+  sp_expect_str_eq_c(t, sdk.version.str, "1.2.3.4");
+  sp_expect_str_eq_c(t, sdk.lib_um, it->expect.lib_um);
+  sp_expect_str_eq_c(t, sdk.lib_ucrt, it->expect.lib_ucrt);
+  sp_expect_str_eq_c(t, sdk.include_ucrt, it->expect.include_ucrt);
+  sp_expect_str_eq_c(t, sdk.include_um, it->expect.include_um);
+  sp_expect_str_eq_c(t, sdk.include_shared, it->expect.include_shared);
+  return SP_OK;
+}

--- a/test/msvc/sdk.c
+++ b/test/msvc/sdk.c
@@ -39,15 +39,22 @@ static const test_t tests [] = {
 };
 
 sp_test_each(msvc, sdk_new, test_t, tests) {
-  sp_msvc_sdk_t sdk = sp_msvc_sdk_new(
-    sp_test_arena(t), it->arch, sp_str_lit("C:/K"), sp_str_lit("1.2.3.4")
-  );
-  sp_expect_str_eq_c(t, sdk.root, "C:/K");
-  sp_expect_str_eq_c(t, sdk.version.str, "1.2.3.4");
-  sp_expect_str_eq_c(t, sdk.lib_um, it->expect.lib_um);
-  sp_expect_str_eq_c(t, sdk.lib_ucrt, it->expect.lib_ucrt);
-  sp_expect_str_eq_c(t, sdk.include_ucrt, it->expect.include_ucrt);
-  sp_expect_str_eq_c(t, sdk.include_um, it->expect.include_um);
-  sp_expect_str_eq_c(t, sdk.include_shared, it->expect.include_shared);
+  sp_msvc_sdk_t sdk = sp_msvc_sdk_new(it->arch, sp_str_lit("C:/K"), sp_str_lit("1.2.3.4"));
+  sp_expect_str_eq_c(t, sp_msvc_path_str(&sdk.root), "C:/K");
+  sp_expect_str_eq_c(t, sp_msvc_version_str(&sdk.version), "1.2.3.4");
+  sp_expect_eq(t, sdk.arch, it->arch);
+
+  sp_msvc_sdk_paths_t paths = sp_msvc_sdk_render(sp_test_arena(t), &sdk);
+  sp_expect_str_eq_c(t, paths.lib_um, it->expect.lib_um);
+  sp_expect_str_eq_c(t, paths.lib_ucrt, it->expect.lib_ucrt);
+  sp_expect_str_eq_c(t, paths.include_ucrt, it->expect.include_ucrt);
+  sp_expect_str_eq_c(t, paths.include_um, it->expect.include_um);
+  sp_expect_str_eq_c(t, paths.include_shared, it->expect.include_shared);
+
+  c8 buf [SP_MSVC_PATH_MAX] = sp_zero;
+  sp_expect_str_eq_c(t, sp_msvc_sdk_path_buf(buf, sizeof(buf), &sdk, SP_MSVC_SDK_PATH_LIB_UM).value, it->expect.lib_um);
+
+  c8 small [8] = sp_zero;
+  sp_expect_eq(t, sp_msvc_sdk_path_buf(small, sizeof(small), &sdk, SP_MSVC_SDK_PATH_LIB_UM).err, SP_ERR_IO_NO_SPACE);
   return SP_OK;
 }

--- a/test/msvc/version_gt.c
+++ b/test/msvc/version_gt.c
@@ -1,0 +1,51 @@
+#include "msvc.h"
+
+typedef struct {
+  bool forward;
+  bool reverse;
+} expect_t;
+
+typedef struct {
+  const c8* name;
+  sp_msvc_version_t a;
+  sp_msvc_version_t b;
+  expect_t expect;
+} test_t;
+
+static const test_t tests [] = {
+  {
+    .name = "equal",
+    .a = { .major = 1, .minor = 2, .build = 3, .revision = 4 },
+    .b = { .major = 1, .minor = 2, .build = 3, .revision = 4 },
+  },
+  {
+    .name = "major",
+    .a = { .major = 2 },
+    .b = { .major = 1, .minor = 9, .build = 9, .revision = 9 },
+    .expect = { .forward = true },
+  },
+  {
+    .name = "minor",
+    .a = { .major = 1, .minor = 1 },
+    .b = { .major = 1, .build = 9, .revision = 9 },
+    .expect = { .forward = true },
+  },
+  {
+    .name = "build",
+    .a = { .major = 1, .build = 2 },
+    .b = { .major = 1, .build = 1, .revision = 9 },
+    .expect = { .forward = true },
+  },
+  {
+    .name = "revision",
+    .a = { .major = 1, .revision = 2 },
+    .b = { .major = 1, .revision = 1 },
+    .expect = { .forward = true },
+  },
+};
+
+sp_test_each(msvc, version_gt, test_t, tests) {
+  sp_expect_eq(t, sp_msvc_version_gt(it->a, it->b), it->expect.forward);
+  sp_expect_eq(t, sp_msvc_version_gt(it->b, it->a), it->expect.reverse);
+  return SP_OK;
+}

--- a/test/msvc/vs.c
+++ b/test/msvc/vs.c
@@ -8,13 +8,14 @@ typedef struct {
 
 typedef struct {
   const c8* name;
-  sp_msvc_arch_t arch;
+  sp_msvc_arch_t host;
+  sp_msvc_arch_t target;
   expect_t expect;
 } test_t;
 
 static const test_t tests [] = {
   {
-    .name = "x64",
+    .name = "x64_to_x64",
     .expect = {
       .lib     = "C:/V/VC/Tools/MSVC/1.2.3/Lib/x64",
       .include = "C:/V/VC/Tools/MSVC/1.2.3/include",
@@ -22,12 +23,21 @@ static const test_t tests [] = {
     },
   },
   {
-    .name = "arm64",
-    .arch = SP_MSVC_ARCH_ARM64,
+    .name = "x64_to_arm64",
+    .target = SP_MSVC_ARCH_ARM64,
     .expect = {
       .lib     = "C:/V/VC/Tools/MSVC/1.2.3/Lib/arm64",
       .include = "C:/V/VC/Tools/MSVC/1.2.3/include",
       .bin     = "C:/V/VC/Tools/MSVC/1.2.3/bin/Hostx64/arm64",
+    },
+  },
+  {
+    .name = "arm64_to_x64",
+    .host = SP_MSVC_ARCH_ARM64,
+    .expect = {
+      .lib     = "C:/V/VC/Tools/MSVC/1.2.3/Lib/x64",
+      .include = "C:/V/VC/Tools/MSVC/1.2.3/include",
+      .bin     = "C:/V/VC/Tools/MSVC/1.2.3/bin/Hostarm64/x64",
     },
   },
 };
@@ -38,7 +48,7 @@ sp_test_each(msvc, vs_new, test_t, tests) {
     .build_version = sp_str_lit("17.14.6"),
     .product_line = sp_str_lit("2022"),
   };
-  sp_msvc_vs_t vs = sp_msvc_vs_new(sp_test_arena(t), it->arch, state, sp_str_lit("1.2.3"));
+  sp_msvc_vs_t vs = sp_msvc_vs_new(sp_test_arena(t), it->host, it->target, state, sp_str_lit("1.2.3"));
 
   sp_expect_str_eq_c(t, vs.install_path, "C:/V");
   sp_expect_str_eq_c(t, vs.version.product, "2022");

--- a/test/msvc/vs.c
+++ b/test/msvc/vs.c
@@ -1,0 +1,51 @@
+#include "msvc.h"
+
+typedef struct {
+  const c8* lib;
+  const c8* include;
+  const c8* bin;
+} expect_t;
+
+typedef struct {
+  const c8* name;
+  sp_msvc_arch_t arch;
+  expect_t expect;
+} test_t;
+
+static const test_t tests [] = {
+  {
+    .name = "x64",
+    .expect = {
+      .lib     = "C:/V/VC/Tools/MSVC/1.2.3/Lib/x64",
+      .include = "C:/V/VC/Tools/MSVC/1.2.3/include",
+      .bin     = "C:/V/VC/Tools/MSVC/1.2.3/bin/Hostx64/x64",
+    },
+  },
+  {
+    .name = "arm64",
+    .arch = SP_MSVC_ARCH_ARM64,
+    .expect = {
+      .lib     = "C:/V/VC/Tools/MSVC/1.2.3/Lib/arm64",
+      .include = "C:/V/VC/Tools/MSVC/1.2.3/include",
+      .bin     = "C:/V/VC/Tools/MSVC/1.2.3/bin/Hostx64/arm64",
+    },
+  },
+};
+
+sp_test_each(msvc, vs_new, test_t, tests) {
+  sp_msvc_state_t state = {
+    .install_path = sp_str_lit("C:/V"),
+    .build_version = sp_str_lit("17.14.6"),
+    .product_line = sp_str_lit("2022"),
+  };
+  sp_msvc_vs_t vs = sp_msvc_vs_new(sp_test_arena(t), it->arch, state, sp_str_lit("1.2.3"));
+
+  sp_expect_str_eq_c(t, vs.install_path, "C:/V");
+  sp_expect_str_eq_c(t, vs.version.product, "2022");
+  sp_expect_str_eq_c(t, vs.version.build.str, "17.14.6");
+  sp_expect_str_eq_c(t, vs.version.tools.str, "1.2.3");
+  sp_expect_str_eq_c(t, vs.lib, it->expect.lib);
+  sp_expect_str_eq_c(t, vs.include, it->expect.include);
+  sp_expect_str_eq_c(t, vs.bin, it->expect.bin);
+  return SP_OK;
+}

--- a/test/msvc/vs.c
+++ b/test/msvc/vs.c
@@ -44,18 +44,22 @@ static const test_t tests [] = {
 
 sp_test_each(msvc, vs_new, test_t, tests) {
   sp_msvc_state_t state = {
-    .install_path = sp_str_lit("C:/V"),
-    .build_version = sp_str_lit("17.14.6"),
-    .product_line = sp_str_lit("2022"),
+    .install_path = sp_msvc_path_new(sp_str_lit("C:/V")),
+    .build_version = sp_msvc_path_new(sp_str_lit("17.14.6")),
+    .product_line = sp_msvc_path_new(sp_str_lit("2022")),
   };
-  sp_msvc_vs_t vs = sp_msvc_vs_new(sp_test_arena(t), it->host, it->target, state, sp_str_lit("1.2.3"));
+  sp_msvc_vs_t vs = sp_msvc_vs_new(it->host, it->target, &state, sp_str_lit("1.2.3"));
 
-  sp_expect_str_eq_c(t, vs.install_path, "C:/V");
-  sp_expect_str_eq_c(t, vs.version.product, "2022");
-  sp_expect_str_eq_c(t, vs.version.build.str, "17.14.6");
-  sp_expect_str_eq_c(t, vs.version.tools.str, "1.2.3");
-  sp_expect_str_eq_c(t, vs.lib, it->expect.lib);
-  sp_expect_str_eq_c(t, vs.include, it->expect.include);
-  sp_expect_str_eq_c(t, vs.bin, it->expect.bin);
+  sp_expect_str_eq_c(t, sp_msvc_path_str(&vs.install_path), "C:/V");
+  sp_expect_str_eq_c(t, sp_msvc_version_str(&vs.version.product), "2022");
+  sp_expect_str_eq_c(t, sp_msvc_version_str(&vs.version.build), "17.14.6");
+  sp_expect_str_eq_c(t, sp_msvc_version_str(&vs.version.tools), "1.2.3");
+  sp_expect_eq(t, vs.host, it->host);
+  sp_expect_eq(t, vs.target, it->target);
+
+  sp_msvc_vs_paths_t paths = sp_msvc_vs_render(sp_test_arena(t), &vs);
+  sp_expect_str_eq_c(t, paths.lib, it->expect.lib);
+  sp_expect_str_eq_c(t, paths.include, it->expect.include);
+  sp_expect_str_eq_c(t, paths.bin, it->expect.bin);
   return SP_OK;
 }


### PR DESCRIPTION
Generally preparing this for getting used in `spn`, which just means making it generally useful. It doesn't allocate anymore, unless you ask it nicely. And the core is functional and testable.